### PR TITLE
Allow searching using substring matching

### DIFF
--- a/src/main/java/seedu/address/commons/util/StringUtil.java
+++ b/src/main/java/seedu/address/commons/util/StringUtil.java
@@ -39,6 +39,33 @@ public class StringUtil {
     }
 
     /**
+     * Returns true if the {@code sentence} contains a substring that is {@code word}
+     *   Ignores case, and a full word match is not required.
+     *   <br>examples:<pre>
+     *       containsSubstringIgnoreCase("ABc def", "ab") == true
+     *       containsSubstringIgnoreCase("ABc def", "DE") == true
+     *       containsSubstringIgnoreCase("ABc def", "z") == false //none of the characters are "z" or "Z"
+     *   </pre>
+     * @param sentence cannot be null
+     * @param substring cannot be null, cannot be empty, must be a single word
+     */
+    public static boolean containsSubstringIgnoreCase(String sentence, String substring) {
+        requireNonNull(sentence);
+        requireNonNull(substring);
+
+        String preppedSubstring = substring.trim();
+        checkArgument(!preppedSubstring.isEmpty(), "Word parameter cannot be empty");
+        checkArgument(preppedSubstring.split("\\s+").length == 1, "Word parameter should be a single word");
+
+        String preppedSentence = sentence;
+        String[] wordsInPreppedSentence = preppedSentence.split("\\s+");
+
+        return Arrays.stream(wordsInPreppedSentence)
+                .map(String::toLowerCase)
+                .anyMatch(word -> word.contains(substring.toLowerCase()));
+    }
+
+    /**
      * Returns a detailed message of the t, including the stack trace.
      */
     public static String getDetails(Throwable t) {

--- a/src/main/java/seedu/address/model/person/NameContainsKeywordsPredicate.java
+++ b/src/main/java/seedu/address/model/person/NameContainsKeywordsPredicate.java
@@ -19,7 +19,7 @@ public class NameContainsKeywordsPredicate implements Predicate<Person> {
     @Override
     public boolean test(Person person) {
         return keywords.stream()
-                .anyMatch(keyword -> StringUtil.containsWordIgnoreCase(person.getName().fullName, keyword));
+                .anyMatch(keyword -> StringUtil.containsSubstringIgnoreCase(person.getName().fullName, keyword));
     }
 
     @Override


### PR DESCRIPTION
Fixes #50 

`Find` now searches contacts with names that contains substrings (case-insensitive) provided by the user.