### PR TITLE
Add Attendance into schema

### DIFF
--- a/src/main/java/seedu/address/logic/commands/EditCommand.java
+++ b/src/main/java/seedu/address/logic/commands/EditCommand.java
@@ -21,6 +21,7 @@ import seedu.address.commons.util.ToStringBuilder;
 import seedu.address.logic.Messages;
 import seedu.address.logic.commands.exceptions.CommandException;
 import seedu.address.model.Model;
+import seedu.address.model.attendance.Attendance;
 import seedu.address.model.person.Email;
 import seedu.address.model.person.Name;
 import seedu.address.model.person.Person;
@@ -101,8 +102,9 @@ public class EditCommand extends Command {
         Email updatedEmail = editPersonDescriptor.getEmail().orElse(personToEdit.getEmail());
         Telegram updatedAddress = editPersonDescriptor.getTelegram().orElse(personToEdit.getTelegram());
         Set<Role> updatedRoles = editPersonDescriptor.getRoles().orElse(personToEdit.getRoles());
+        Set<Attendance> attendance = personToEdit.getAttendance();
 
-        return new Person(updatedName, updatedPhone, updatedEmail, updatedAddress, updatedRoles);
+        return new Person(updatedName, updatedPhone, updatedEmail, updatedAddress, updatedRoles, attendance);
     }
 
     @Override

--- a/src/main/java/seedu/address/logic/parser/AddCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/AddCommandParser.java
@@ -7,11 +7,13 @@ import static seedu.address.logic.parser.CliSyntax.PREFIX_PHONE;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_ROLE;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_TELEGRAM;
 
+import java.util.HashSet;
 import java.util.Set;
 import java.util.stream.Stream;
 
 import seedu.address.logic.commands.AddCommand;
 import seedu.address.logic.parser.exceptions.ParseException;
+import seedu.address.model.attendance.Attendance;
 import seedu.address.model.person.Email;
 import seedu.address.model.person.Name;
 import seedu.address.model.person.Person;
@@ -44,8 +46,9 @@ public class AddCommandParser implements Parser<AddCommand> {
         Email email = ParserUtil.parseEmail(argMultimap.getValue(PREFIX_EMAIL).get());
         Telegram telegram = ParserUtil.parseTelegram(argMultimap.getValue(PREFIX_TELEGRAM).get());
         Set<Role> roleList = ParserUtil.parseRoles(argMultimap.getAllValues(PREFIX_ROLE));
+        Set<Attendance> emptyAttendanceList = new HashSet<>();
 
-        Person person = new Person(name, phone, email, telegram, roleList);
+        Person person = new Person(name, phone, email, telegram, roleList, emptyAttendanceList);
 
         return new AddCommand(person);
     }

--- a/src/main/java/seedu/address/logic/parser/ParserUtil.java
+++ b/src/main/java/seedu/address/logic/parser/ParserUtil.java
@@ -111,7 +111,7 @@ public class ParserUtil {
     }
 
     /**
-     * Parses {@code Collection<String> tags} into a {@code Set<Role>}.
+     * Parses {@code Collection<String> roles} into a {@code Set<Role>}.
      */
     public static Set<Role> parseRoles(Collection<String> roles) throws ParseException {
         requireNonNull(roles);

--- a/src/main/java/seedu/address/model/attendance/Attendance.java
+++ b/src/main/java/seedu/address/model/attendance/Attendance.java
@@ -6,6 +6,10 @@ import static seedu.address.commons.util.AppUtil.checkArgument;
 import java.time.LocalDate;
 import java.time.format.DateTimeParseException;
 
+/**
+ * Represents an Attendance session for a contact in the address book.
+ * Guarantees: immutable; session is valid as declared in {@link #isValidDate(String)}
+ */
 public class Attendance {
 
     public static final String MESSAGE_CONSTRAINTS = "Session date should be valid and "
@@ -15,6 +19,11 @@ public class Attendance {
             "^\\d{4}\\-(0[1-9]|1[012])\\-(0[1-9]|[12][0-9]|3[01])$";
     public final LocalDate session; // LocalDate is immutable
 
+    /**
+     * Constructs a {@code Attendance}.
+     *
+     * @param date A valid date string in the form YYYY-MM-DD.
+     */
     public Attendance(String date) {
         requireNonNull(date);
         checkArgument(isValidDate(date), MESSAGE_CONSTRAINTS);
@@ -23,9 +32,13 @@ public class Attendance {
 
     /**
      * Returns true if a given string is a valid date.
+     * This checks for both string formatting and whether the date is an actual
+     * date (e.g. "2020-02-31" will return false)
+     *
+     * @param test A test date string.
+     * @return Boolean representing validity of test date string
      */
     public static boolean isValidDate(String test) {
-        // return test.matches(VALIDATION_REGEX);
         try {
             LocalDate.parse(test);
             return test.matches(VALIDATION_REGEX);

--- a/src/main/java/seedu/address/model/attendance/Attendance.java
+++ b/src/main/java/seedu/address/model/attendance/Attendance.java
@@ -1,0 +1,60 @@
+package seedu.address.model.attendance;
+
+import static java.util.Objects.requireNonNull;
+import static seedu.address.commons.util.AppUtil.checkArgument;
+
+import java.time.LocalDate;
+import java.time.format.DateTimeParseException;
+
+public class Attendance {
+
+    public static final String MESSAGE_CONSTRAINTS = "Session date should be valid and "
+            + "in the form YYYY-MM-DD";
+
+    public static final String VALIDATION_REGEX =
+            "^\\d{4}\\-(0[1-9]|1[012])\\-(0[1-9]|[12][0-9]|3[01])$";
+    public final LocalDate session; // LocalDate is immutable
+
+    public Attendance(String date) {
+        requireNonNull(date);
+        checkArgument(isValidDate(date), MESSAGE_CONSTRAINTS);
+        session = LocalDate.parse(date);
+    }
+
+    /**
+     * Returns true if a given string is a valid date.
+     */
+    public static boolean isValidDate(String test) {
+        // return test.matches(VALIDATION_REGEX);
+        try {
+            LocalDate.parse(test);
+            return test.matches(VALIDATION_REGEX);
+        } catch (DateTimeParseException e) {
+            return false;
+        }
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        if (other == this) {
+            return true;
+        }
+
+        if (!(other instanceof Attendance)) {
+            return false;
+        }
+
+        Attendance otherAttendance = (Attendance) other;
+        return session.equals(otherAttendance.session);
+    }
+
+    @Override
+    public String toString() {
+        return '[' + session.toString() + ']';
+    }
+
+    @Override
+    public int hashCode() {
+        return session.hashCode();
+    }
+}

--- a/src/main/java/seedu/address/model/person/Person.java
+++ b/src/main/java/seedu/address/model/person/Person.java
@@ -10,6 +10,7 @@ import java.util.Objects;
 import java.util.Set;
 
 import seedu.address.commons.util.ToStringBuilder;
+import seedu.address.model.attendance.Attendance;
 import seedu.address.model.role.Role;
 
 /**
@@ -26,17 +27,20 @@ public class Person {
 
     // Data fields
     private final Set<Role> roles = new HashSet<>();
+    private final Set<Attendance> attendance = new HashSet<>();
 
     /**
      * Every field must be present and not null.
      */
-    public Person(Name name, Phone phone, Email email, Telegram telegram, Set<Role> roles) {
+    public Person(Name name, Phone phone, Email email, Telegram telegram,
+                  Set<Role> roles, Set<Attendance> attendance) {
         requireAllNonNull(name, phone, email, telegram, roles);
         this.name = name;
         this.phone = phone;
         this.email = email;
         this.telegram = telegram;
         this.roles.addAll(roles);
+        this.attendance.addAll(attendance);
     }
 
     public Name getName() {
@@ -56,11 +60,20 @@ public class Person {
     }
 
     /**
-     * Returns an immutable tag set, which throws {@code UnsupportedOperationException}
+     * Returns an immutable role set, which throws {@code UnsupportedOperationException}
      * if modification is attempted.
      */
     public Set<Role> getRoles() {
         return Collections.unmodifiableSet(roles);
+    }
+
+    /**
+     * Returns an immutable attendance set, which throws {@code UnsupportedOperationException}
+     * if modification is attempted
+     * @return the attendance set encapsulated by Person
+     */
+    public Set<Attendance> getAttendance() {
+        return Collections.unmodifiableSet(attendance);
     }
 
     /**

--- a/src/main/java/seedu/address/model/util/SampleDataUtil.java
+++ b/src/main/java/seedu/address/model/util/SampleDataUtil.java
@@ -1,6 +1,7 @@
 package seedu.address.model.util;
 
 import java.util.Arrays;
+import java.util.HashSet;
 import java.util.Set;
 import java.util.stream.Collectors;
 
@@ -18,25 +19,32 @@ import seedu.address.model.role.Role;
  */
 public class SampleDataUtil {
     public static Person[] getSamplePersons() {
+        // TODO: change sample persons to match our CCA context
         return new Person[] {
             new Person(new Name("Alex Yeoh"), new Phone("87438807"), new Email("alexyeoh@example.com"),
                 new Telegram("alexYeoh"),
-                getRoleSet("friends")),
+                getRoleSet("friends"),
+                new HashSet<>()),
             new Person(new Name("Bernice Yu"), new Phone("99272758"), new Email("berniceyu@example.com"),
                 new Telegram("berniceYu"),
-                getRoleSet("colleagues", "friends")),
+                getRoleSet("colleagues", "friends"),
+                new HashSet<>()),
             new Person(new Name("Charlotte Oliveiro"), new Phone("93210283"), new Email("charlotte@example.com"),
                 new Telegram("charlotte"),
-                getRoleSet("neighbours")),
+                getRoleSet("neighbours"),
+                new HashSet<>()),
             new Person(new Name("David Li"), new Phone("91031282"), new Email("lidavid@example.com"),
                 new Telegram("davidLi"),
-                getRoleSet("family")),
+                getRoleSet("family"),
+                new HashSet<>()),
             new Person(new Name("Irfan Ibrahim"), new Phone("92492021"), new Email("irfan@example.com"),
                 new Telegram("irfanIbrahim"),
-                getRoleSet("classmates")),
+                getRoleSet("classmates"),
+                new HashSet<>()),
             new Person(new Name("Roy Balakrishnan"), new Phone("92624417"), new Email("royb@example.com"),
                 new Telegram("royBala"),
-                getRoleSet("colleagues"))
+                getRoleSet("colleagues"),
+                new HashSet<>())
         };
     }
 

--- a/src/main/java/seedu/address/storage/JsonAdaptedAttendance.java
+++ b/src/main/java/seedu/address/storage/JsonAdaptedAttendance.java
@@ -1,0 +1,33 @@
+package seedu.address.storage;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonValue;
+
+import seedu.address.commons.exceptions.IllegalValueException;
+import seedu.address.model.attendance.Attendance;
+
+public class JsonAdaptedAttendance {
+    private final String session; // tbd
+
+    @JsonCreator
+    public JsonAdaptedAttendance(String date) {
+        this.session = date;
+    }
+
+    public JsonAdaptedAttendance(Attendance source) {
+        this.session = source.session.toString();
+    }
+
+    @JsonValue
+    public String getSession() {
+        return session;
+    }
+
+    public Attendance toModelType() throws IllegalValueException {
+        if (!Attendance.isValidDate(session)) {
+            throw new IllegalValueException(Attendance.MESSAGE_CONSTRAINTS);
+        }
+        return new Attendance(session);
+    }
+
+}

--- a/src/main/java/seedu/address/storage/JsonAdaptedAttendance.java
+++ b/src/main/java/seedu/address/storage/JsonAdaptedAttendance.java
@@ -6,23 +6,40 @@ import com.fasterxml.jackson.annotation.JsonValue;
 import seedu.address.commons.exceptions.IllegalValueException;
 import seedu.address.model.attendance.Attendance;
 
+/**
+ * Jackson-friendly version of {@link Attendance}.
+ */
 public class JsonAdaptedAttendance {
-    private final String session; // tbd
+    /** Unlike in Attendance, session is represented as a simple String here */
+    private final String session;
 
+    /**
+     * Constructs a {@code JsonAdaptedAttendance} with the given {@code date}.
+     *
+     */
     @JsonCreator
     public JsonAdaptedAttendance(String date) {
         this.session = date;
     }
 
+    /**
+     * Converts a given {@code Attendance} into JsonAdaptedAttendance for Jackson use.
+     */
     public JsonAdaptedAttendance(Attendance source) {
         this.session = source.session.toString();
     }
+
 
     @JsonValue
     public String getSession() {
         return session;
     }
 
+    /**
+     * Converts this Jackson-friendly adapted attendance object into the model's {@code Attendance} object.
+     *
+     * @throws IllegalValueException if there were any data constraints violated in the adapted attendance.
+     */
     public Attendance toModelType() throws IllegalValueException {
         if (!Attendance.isValidDate(session)) {
             throw new IllegalValueException(Attendance.MESSAGE_CONSTRAINTS);

--- a/src/main/java/seedu/address/storage/JsonAdaptedPerson.java
+++ b/src/main/java/seedu/address/storage/JsonAdaptedPerson.java
@@ -4,12 +4,12 @@ import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
-import java.util.stream.Collectors;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
 import seedu.address.commons.exceptions.IllegalValueException;
+import seedu.address.model.attendance.Attendance;
 import seedu.address.model.person.Email;
 import seedu.address.model.person.Name;
 import seedu.address.model.person.Person;
@@ -29,6 +29,7 @@ class JsonAdaptedPerson {
     private final String email;
     private final String telegram;
     private final List<JsonAdaptedRole> roles = new ArrayList<>();
+    private final List<JsonAdaptedAttendance> attendance = new ArrayList<>();
 
     /**
      * Constructs a {@code JsonAdaptedPerson} with the given person details.
@@ -36,13 +37,17 @@ class JsonAdaptedPerson {
     @JsonCreator
     public JsonAdaptedPerson(@JsonProperty("name") String name, @JsonProperty("phone") String phone,
             @JsonProperty("email") String email, @JsonProperty("telegram") String telegram,
-            @JsonProperty("roles") List<JsonAdaptedRole> roles) {
+            @JsonProperty("roles") List<JsonAdaptedRole> roles,
+            @JsonProperty("attendance") List<JsonAdaptedAttendance> attendance) {
         this.name = name;
         this.phone = phone;
         this.email = email;
         this.telegram = telegram;
         if (roles != null) {
             this.roles.addAll(roles);
+        }
+        if (attendance != null) {
+            this.attendance.addAll(attendance);
         }
     }
 
@@ -56,7 +61,10 @@ class JsonAdaptedPerson {
         telegram = source.getTelegram().value;
         roles.addAll(source.getRoles().stream()
                 .map(JsonAdaptedRole::new)
-                .collect(Collectors.toList()));
+                .toList());
+        attendance.addAll(source.getAttendance().stream()
+                .map(JsonAdaptedAttendance::new)
+                .toList());
     }
 
     /**
@@ -66,8 +74,14 @@ class JsonAdaptedPerson {
      */
     public Person toModelType() throws IllegalValueException {
         final List<Role> personRoles = new ArrayList<>();
+        final List<Attendance> personAttendance = new ArrayList<>();
+
         for (JsonAdaptedRole role : roles) {
             personRoles.add(role.toModelType());
+        }
+
+        for (JsonAdaptedAttendance session : attendance) {
+            personAttendance.add(session.toModelType());
         }
 
         if (name == null) {
@@ -103,7 +117,8 @@ class JsonAdaptedPerson {
         }
         final Telegram modelTelegram = new Telegram(telegram);
         final Set<Role> modelRoles = new HashSet<>(personRoles);
-        return new Person(modelName, modelPhone, modelEmail, modelTelegram, modelRoles);
+        final Set<Attendance> modelAttendance = new HashSet<>(personAttendance);
+        return new Person(modelName, modelPhone, modelEmail, modelTelegram, modelRoles, modelAttendance);
     }
 
 }

--- a/src/main/java/seedu/address/storage/JsonAdaptedRole.java
+++ b/src/main/java/seedu/address/storage/JsonAdaptedRole.java
@@ -14,7 +14,7 @@ class JsonAdaptedRole {
     private final String roleName;
 
     /**
-     * Constructs a {@code JsonAdaptedTag} with the given {@code tagName}.
+     * Constructs a {@code JsonAdaptedTag} with the given {@code roleName}.
      */
     @JsonCreator
     public JsonAdaptedRole(String roleName) {

--- a/src/test/data/JsonSerializableAddressBookTest/typicalPersonsAddressBook.json
+++ b/src/test/data/JsonSerializableAddressBookTest/typicalPersonsAddressBook.json
@@ -5,42 +5,49 @@
     "phone" : "94351253",
     "email" : "alice@example.com",
     "telegram" : "alicePauline",
-    "roles" : [ ]
+    "roles" : [ ],
+    "attendance": [ ]
   }, {
     "name" : "Benson Meier",
     "phone" : "98765432",
     "email" : "johnd@example.com",
     "telegram" : "bensonMeier",
-    "roles" : [ ]
+    "roles" : [ ],
+    "attendance": [ ]
   }, {
     "name" : "Carl Kurz",
     "phone" : "95352563",
     "email" : "heinz@example.com",
     "telegram" : "carlKurz",
-    "roles" : [ ]
+    "roles" : [ ],
+    "attendance": [ ]
   }, {
     "name" : "Daniel Meier",
     "phone" : "87652533",
     "email" : "cornelia@example.com",
     "telegram" : "danMeier",
-    "roles" : [ ]
+    "roles" : [ ],
+    "attendance": [ ]
   }, {
     "name" : "Elle Meyer",
     "phone" : "94822224",
     "email" : "werner@example.com",
     "telegram" : "elleMeyer",
-    "roles" : [ ]
+    "roles" : [ ],
+    "attendance": [ ]
   }, {
     "name" : "Fiona Kunz",
     "phone" : "94822427",
     "email" : "lydia@example.com",
     "telegram" : "fionaKunz",
-    "roles" : [ ]
+    "roles" : [ ],
+    "attendance": [ ]
   }, {
     "name" : "George Best",
     "phone" : "94822442",
     "email" : "anna@example.com",
     "telegram" : "georgeBest",
-    "roles" : [ ]
+    "roles" : [ ],
+    "attendance": [ ]
   } ]
 }

--- a/src/test/java/seedu/address/storage/JsonAdaptedPersonTest.java
+++ b/src/test/java/seedu/address/storage/JsonAdaptedPersonTest.java
@@ -31,6 +31,7 @@ public class JsonAdaptedPersonTest {
     private static final List<JsonAdaptedRole> VALID_ROLES = BENSON.getRoles().stream()
             .map(JsonAdaptedRole::new)
             .collect(Collectors.toList());
+    private static final List<JsonAdaptedAttendance> VALID_ATTENDANCE = new ArrayList<>();
 
     @Test
     public void toModelType_validPersonDetails_returnsPerson() throws Exception {
@@ -40,60 +41,64 @@ public class JsonAdaptedPersonTest {
 
     @Test
     public void toModelType_invalidName_throwsIllegalValueException() {
-        JsonAdaptedPerson person =
-                new JsonAdaptedPerson(INVALID_NAME, VALID_PHONE, VALID_EMAIL, VALID_TELEGRAM, VALID_ROLES);
+        JsonAdaptedPerson person = new JsonAdaptedPerson(INVALID_NAME, VALID_PHONE,
+                VALID_EMAIL, VALID_TELEGRAM, VALID_ROLES, VALID_ATTENDANCE);
         String expectedMessage = Name.MESSAGE_CONSTRAINTS;
         assertThrows(IllegalValueException.class, expectedMessage, person::toModelType);
     }
 
     @Test
     public void toModelType_nullName_throwsIllegalValueException() {
-        JsonAdaptedPerson person = new JsonAdaptedPerson(null, VALID_PHONE, VALID_EMAIL, VALID_TELEGRAM, VALID_ROLES);
+        JsonAdaptedPerson person = new JsonAdaptedPerson(null, VALID_PHONE,
+                VALID_EMAIL, VALID_TELEGRAM, VALID_ROLES, VALID_ATTENDANCE);
         String expectedMessage = String.format(MISSING_FIELD_MESSAGE_FORMAT, Name.class.getSimpleName());
         assertThrows(IllegalValueException.class, expectedMessage, person::toModelType);
     }
 
     @Test
     public void toModelType_invalidPhone_throwsIllegalValueException() {
-        JsonAdaptedPerson person =
-                new JsonAdaptedPerson(VALID_NAME, INVALID_PHONE, VALID_EMAIL, VALID_TELEGRAM, VALID_ROLES);
+        JsonAdaptedPerson person = new JsonAdaptedPerson(VALID_NAME, INVALID_PHONE,
+                VALID_EMAIL, VALID_TELEGRAM, VALID_ROLES, VALID_ATTENDANCE);
         String expectedMessage = Phone.MESSAGE_CONSTRAINTS;
         assertThrows(IllegalValueException.class, expectedMessage, person::toModelType);
     }
 
     @Test
     public void toModelType_nullPhone_throwsIllegalValueException() {
-        JsonAdaptedPerson person = new JsonAdaptedPerson(VALID_NAME, null, VALID_EMAIL, VALID_TELEGRAM, VALID_ROLES);
+        JsonAdaptedPerson person = new JsonAdaptedPerson(VALID_NAME, null,
+                VALID_EMAIL, VALID_TELEGRAM, VALID_ROLES, VALID_ATTENDANCE);
         String expectedMessage = String.format(MISSING_FIELD_MESSAGE_FORMAT, Phone.class.getSimpleName());
         assertThrows(IllegalValueException.class, expectedMessage, person::toModelType);
     }
 
     @Test
     public void toModelType_invalidEmail_throwsIllegalValueException() {
-        JsonAdaptedPerson person =
-                new JsonAdaptedPerson(VALID_NAME, VALID_PHONE, INVALID_EMAIL, VALID_TELEGRAM, VALID_ROLES);
+        JsonAdaptedPerson person = new JsonAdaptedPerson(VALID_NAME, VALID_PHONE,
+                        INVALID_EMAIL, VALID_TELEGRAM, VALID_ROLES, VALID_ATTENDANCE);
         String expectedMessage = Email.MESSAGE_CONSTRAINTS;
         assertThrows(IllegalValueException.class, expectedMessage, person::toModelType);
     }
 
     @Test
     public void toModelType_nullEmail_throwsIllegalValueException() {
-        JsonAdaptedPerson person = new JsonAdaptedPerson(VALID_NAME, VALID_PHONE, null, VALID_TELEGRAM, VALID_ROLES);
+        JsonAdaptedPerson person = new JsonAdaptedPerson(VALID_NAME, VALID_PHONE,
+                null, VALID_TELEGRAM, VALID_ROLES, VALID_ATTENDANCE);
         String expectedMessage = String.format(MISSING_FIELD_MESSAGE_FORMAT, Email.class.getSimpleName());
         assertThrows(IllegalValueException.class, expectedMessage, person::toModelType);
     }
 
     @Test
     public void toModelType_invalidTelegram_throwsIllegalValueException() {
-        JsonAdaptedPerson person =
-                new JsonAdaptedPerson(VALID_NAME, VALID_PHONE, VALID_EMAIL, INVALID_TELEGRAM, VALID_ROLES);
+        JsonAdaptedPerson person = new JsonAdaptedPerson(VALID_NAME, VALID_PHONE,
+                VALID_EMAIL, INVALID_TELEGRAM, VALID_ROLES, VALID_ATTENDANCE);
         String expectedMessage = Telegram.MESSAGE_CONSTRAINTS;
         assertThrows(IllegalValueException.class, expectedMessage, person::toModelType);
     }
 
     @Test
     public void toModelType_nullTelegram_throwsIllegalValueException() {
-        JsonAdaptedPerson person = new JsonAdaptedPerson(VALID_NAME, VALID_PHONE, VALID_EMAIL, null, VALID_ROLES);
+        JsonAdaptedPerson person = new JsonAdaptedPerson(VALID_NAME, VALID_PHONE,
+                VALID_EMAIL, null, VALID_ROLES, VALID_ATTENDANCE);
         String expectedMessage = String.format(MISSING_FIELD_MESSAGE_FORMAT, Telegram.class.getSimpleName());
         assertThrows(IllegalValueException.class, expectedMessage, person::toModelType);
     }
@@ -102,9 +107,11 @@ public class JsonAdaptedPersonTest {
     public void toModelType_invalidRoles_throwsIllegalValueException() {
         List<JsonAdaptedRole> invalidRoles = new ArrayList<>(VALID_ROLES);
         invalidRoles.add(new JsonAdaptedRole(INVALID_ROLE));
-        JsonAdaptedPerson person =
-                new JsonAdaptedPerson(VALID_NAME, VALID_PHONE, VALID_EMAIL, VALID_TELEGRAM, invalidRoles);
+        JsonAdaptedPerson person = new JsonAdaptedPerson(VALID_NAME, VALID_PHONE,
+                VALID_EMAIL, VALID_TELEGRAM, invalidRoles, VALID_ATTENDANCE);
         assertThrows(IllegalValueException.class, person::toModelType);
     }
+
+    // TODO: test for invalid/valid attendance
 
 }

--- a/src/test/java/seedu/address/testutil/PersonBuilder.java
+++ b/src/test/java/seedu/address/testutil/PersonBuilder.java
@@ -3,6 +3,7 @@ package seedu.address.testutil;
 import java.util.HashSet;
 import java.util.Set;
 
+import seedu.address.model.attendance.Attendance;
 import seedu.address.model.person.Email;
 import seedu.address.model.person.Name;
 import seedu.address.model.person.Person;
@@ -26,6 +27,7 @@ public class PersonBuilder {
     private Email email;
     private Telegram telegram;
     private Set<Role> roles;
+    private Set<Attendance> attendance;
 
     /**
      * Creates a {@code PersonBuilder} with the default details.
@@ -36,6 +38,7 @@ public class PersonBuilder {
         email = new Email(DEFAULT_EMAIL);
         telegram = new Telegram(DEFAULT_TELEGRAM);
         roles = new HashSet<>();
+        attendance = new HashSet<>();
     }
 
     /**
@@ -47,6 +50,7 @@ public class PersonBuilder {
         email = personToCopy.getEmail();
         telegram = personToCopy.getTelegram();
         roles = new HashSet<>(personToCopy.getRoles());
+        attendance = new HashSet<>(personToCopy.getAttendance());
     }
 
     /**
@@ -60,10 +64,12 @@ public class PersonBuilder {
     /**
      * Parses the {@code roles} into a {@code Set<Role>} and set it to the {@code Person} that we are building.
      */
-    public PersonBuilder withRoles(String ... tags) {
-        this.roles = SampleDataUtil.getRoleSet(tags);
+    public PersonBuilder withRoles(String ... roles) {
+        this.roles = SampleDataUtil.getRoleSet(roles);
         return this;
     }
+
+    // TODO: make a withAttendance method like withRoles to help test attendance
 
     /**
      * Sets the {@code Address} of the {@code Person} that we are building.
@@ -90,7 +96,7 @@ public class PersonBuilder {
     }
 
     public Person build() {
-        return new Person(name, phone, email, telegram, roles);
+        return new Person(name, phone, email, telegram, roles, attendance);
     }
 
 }


### PR DESCRIPTION
Fixes #75 

Attendance is structured similar to Role. A Person object has a set of attendance objects.

An Attendance object represents a distinct session that a Person has attended

On json load, attendance validity is checked. In the json file, attendance is an array of strings, with each string being formatted as "YYYY-MM-DD". 

Attendance validity check checks for both string formatting and date validity (e.g. 2020-02-31 is invalid) 

Currently, there is no way for attendance to be added to a Person. This will be changed later with the implementation of the mark and unmark commands
