### PR TITLE
Add switch profile feature

### DIFF
--- a/src/main/java/seedu/address/logic/LogicManager.java
+++ b/src/main/java/seedu/address/logic/LogicManager.java
@@ -3,18 +3,18 @@ package seedu.address.logic;
 import java.io.IOException;
 import java.nio.file.AccessDeniedException;
 import java.nio.file.Path;
-import java.nio.file.Paths;
 import java.util.logging.Logger;
 
 import javafx.collections.ObservableList;
 import seedu.address.commons.core.GuiSettings;
 import seedu.address.commons.core.LogsCenter;
+import seedu.address.commons.exceptions.DataLoadingException;
 import seedu.address.logic.commands.Command;
 import seedu.address.logic.commands.CommandResult;
-import seedu.address.logic.commands.SwitchCommand;
 import seedu.address.logic.commands.exceptions.CommandException;
 import seedu.address.logic.parser.AddressBookParser;
 import seedu.address.logic.parser.exceptions.ParseException;
+import seedu.address.model.AddressBook;
 import seedu.address.model.Model;
 import seedu.address.model.ReadOnlyAddressBook;
 import seedu.address.model.person.Person;
@@ -25,12 +25,11 @@ import seedu.address.storage.Storage;
  */
 public class LogicManager implements Logic {
     public static final String FILE_OPS_ERROR_FORMAT = "Could not save data due to the following error: %s";
-
     public static final String FILE_OPS_PERMISSION_ERROR_FORMAT =
             "Could not save data to file %s due to insufficient permissions to write to the file or the folder.";
+    public static final String FILE_OPS_LOAD_ERROR = "Data file cannot be loaded due to the following error: %s";
 
     private final Logger logger = LogsCenter.getLogger(LogicManager.class);
-
     private final Model model;
     private final Storage storage;
     private final AddressBookParser addressBookParser;
@@ -53,13 +52,15 @@ public class LogicManager implements Logic {
         commandResult = command.execute(model);
 
         try {
-            System.out.println(model.getAddressBookFilePath());
-            storage.updateAddressBookFilePath(model.getAddressBookFilePath());
             storage.saveAddressBook(model.getAddressBook());
+            storage.saveUserPrefs(model.getUserPrefs());
+            syncAddressBook();
         } catch (AccessDeniedException e) {
             throw new CommandException(String.format(FILE_OPS_PERMISSION_ERROR_FORMAT, e.getMessage()), e);
         } catch (IOException ioe) {
             throw new CommandException(String.format(FILE_OPS_ERROR_FORMAT, ioe.getMessage()), ioe);
+        } catch (DataLoadingException dle) {
+            throw new CommandException(String.format(FILE_OPS_LOAD_ERROR, dle.getMessage()));
         }
 
         return commandResult;
@@ -88,5 +89,19 @@ public class LogicManager implements Logic {
     @Override
     public void setGuiSettings(GuiSettings guiSettings) {
         model.setGuiSettings(guiSettings);
+    }
+
+    /**
+     * Synchronize the model with the specified data path in the preference file.
+     * @throws DataLoadingException if loading the data from storage failed.
+     */
+    private void syncAddressBook() throws DataLoadingException {
+        // synchronize path in model and actual file path used
+        storage.updateAddressBookFilePath(model.getAddressBookFilePath());
+
+        // synchronize the data displayed
+        ReadOnlyAddressBook newAddressBook = storage.readAddressBook(getAddressBookFilePath())
+                .orElseGet(AddressBook::new);
+        model.setAddressBook(newAddressBook);
     }
 }

--- a/src/main/java/seedu/address/logic/LogicManager.java
+++ b/src/main/java/seedu/address/logic/LogicManager.java
@@ -3,6 +3,7 @@ package seedu.address.logic;
 import java.io.IOException;
 import java.nio.file.AccessDeniedException;
 import java.nio.file.Path;
+import java.nio.file.Paths;
 import java.util.logging.Logger;
 
 import javafx.collections.ObservableList;
@@ -10,6 +11,7 @@ import seedu.address.commons.core.GuiSettings;
 import seedu.address.commons.core.LogsCenter;
 import seedu.address.logic.commands.Command;
 import seedu.address.logic.commands.CommandResult;
+import seedu.address.logic.commands.SwitchCommand;
 import seedu.address.logic.commands.exceptions.CommandException;
 import seedu.address.logic.parser.AddressBookParser;
 import seedu.address.logic.parser.exceptions.ParseException;
@@ -51,6 +53,8 @@ public class LogicManager implements Logic {
         commandResult = command.execute(model);
 
         try {
+            System.out.println(model.getAddressBookFilePath());
+            storage.updateAddressBookFilePath(model.getAddressBookFilePath());
             storage.saveAddressBook(model.getAddressBook());
         } catch (AccessDeniedException e) {
             throw new CommandException(String.format(FILE_OPS_PERMISSION_ERROR_FORMAT, e.getMessage()), e);

--- a/src/main/java/seedu/address/logic/commands/AddCommand.java
+++ b/src/main/java/seedu/address/logic/commands/AddCommand.java
@@ -51,7 +51,6 @@ public class AddCommand extends Command {
     @Override
     public CommandResult execute(Model model) throws CommandException {
         requireNonNull(model);
-
         if (model.hasPerson(toAdd)) {
             throw new CommandException(MESSAGE_DUPLICATE_PERSON);
         }

--- a/src/main/java/seedu/address/logic/commands/CommandResult.java
+++ b/src/main/java/seedu/address/logic/commands/CommandResult.java
@@ -24,6 +24,8 @@ public class CommandResult {
 
     private Person person = null;
 
+    private boolean profileSwitched = false;
+
     /**
      * Constructs a {@code CommandResult} that's specifically a 'view' command
      * @param feedbackToUser
@@ -73,6 +75,20 @@ public class CommandResult {
 
     public Person getViewPerson() {
         return this.person;
+    }
+
+    public boolean isProfileSwitched() {
+        return this.profileSwitched;
+    }
+
+    /**
+     * Marks that a profile switch has occurred and returns the updated {@code CommandResult}.
+     *
+     * @return The updated {@code CommandResult} with the profile switch marked.
+     */
+    public CommandResult markProfileSwitched() {
+        this.profileSwitched = true;
+        return this;
     }
 
     @Override

--- a/src/main/java/seedu/address/logic/commands/SwitchCommand.java
+++ b/src/main/java/seedu/address/logic/commands/SwitchCommand.java
@@ -4,53 +4,70 @@ import static java.util.Objects.requireNonNull;
 
 import java.nio.file.Path;
 import java.nio.file.Paths;
-import java.util.HashMap;
-import java.util.regex.Pattern;
+import java.util.Set;
+import java.util.stream.Collectors;
 
 import seedu.address.logic.commands.exceptions.CommandException;
-import seedu.address.model.AddressBook;
 import seedu.address.model.Model;
-import seedu.address.model.ReadOnlyAddressBook;
+import seedu.address.model.profile.Profile;
 
+
+/**
+ * Represents a command to switch to a different user profile in the application.
+ * <p>
+ * If the provided profile name is valid, this command will switch the current session to the new profile.
+ * If no profile name is provided (empty input) and other profiles exist, the command will list all available profiles.
+ * If the user attempts to switch to the currently active profile, the command will not perform the switch
+ * </p>
+ */
 public class SwitchCommand extends Command {
-    public static final HashMap<String, ReadOnlyAddressBook> savedProfiles = new HashMap<>();
     public static final String COMMAND_WORD = "switch";
     public static final String COMMAND_ALIAS = "s";
     public static final String MESSAGE_USAGE = COMMAND_WORD
-            + " lorem ipsum blah";
+            + ": Switches to a different profile based on the provided name.\n"
+            + "Parameters: PROFILE_NAME\n"
+            + Profile.MESSAGE_CONSTRAINTS + "\n"
+            + "Example: " + COMMAND_WORD + " john-doe";
+    public static final String MESSAGE_SUCCESS = "Switched to the profile '%1$s'";
+    public static final String MESSAGE_SHOW_PROFILES = "Other profiles: %1$s";
+    public static final String MESSAGE_NO_SWITCH = "Already on: %1$s";
+    public static final String MESSAGE_ILLEGAL_MODIFICATION =
+            "We do not support illegal file modifications. Please ensure the profile name fits our constraints:\n"
+                    + Profile.MESSAGE_CONSTRAINTS;
 
-    public static final String MESSAGE_SUCCESS = "Switched to profile %1$s";
-    public static final String MESSAGE_CONSTRAINT = "msg constraint lorem";
-    private final String profileName;
-    public SwitchCommand(String profileName) {
-        this.profileName = profileName;
+    private final Profile profileName;
+    public SwitchCommand(Profile profileName) {
+        this.profileName = (profileName);
     }
 
     @Override
     public CommandResult execute(Model model) throws CommandException {
         requireNonNull(model);
-        Path filePath = Paths.get("data", profileName + ".json");
 
-        //save current profile
-        String curProfileName = getProfileName(model.getAddressBookFilePath());
-        ReadOnlyAddressBook curAddressBook = model.getFrozenAddressBook();
-        savedProfiles.put(curProfileName, curAddressBook);
-
-        //get the new profile
-        ReadOnlyAddressBook nextAddressBook;
-        if (savedProfiles.containsKey(profileName)) {
-            // profile exists
-            nextAddressBook = savedProfiles.get(profileName);
-        } else {
-            nextAddressBook = new AddressBook();
+        // display all available commands
+        if (profileName instanceof Profile.EmptyProfile) {
+            Set<Profile> profiles = model.getProfiles();
+            if (profiles.isEmpty()) {
+                throw new CommandException(MESSAGE_USAGE);
+            }
+            String profilesList = profiles.stream()
+                    .map(Profile::toString)
+                    .collect(Collectors.joining(", "));
+            return new CommandResult(String.format(MESSAGE_SHOW_PROFILES, profilesList));
         }
 
-        // set next profile
-        System.out.println(model.getAddressBookFilePath());
+        Path filePath = Paths.get("data", profileName + ".json");
+        // updates the model to track the profile switch
+        String curProfileName = getProfileName(model.getAddressBookFilePath());
+        if (!Profile.isValidProfile(curProfileName)) {
+            throw new CommandException(MESSAGE_ILLEGAL_MODIFICATION);
+        }
+        if (curProfileName.equals(profileName.toString())) {
+            return new CommandResult(String.format(MESSAGE_NO_SWITCH, profileName));
+        }
+        model.addToProfiles(new Profile(curProfileName));
         model.setAddressBookFilePath(filePath);
-        System.out.println(model.getAddressBookFilePath());
-        model.setAddressBook(nextAddressBook);
-        return new CommandResult(String.format(MESSAGE_SUCCESS, filePath));
+        return new CommandResult(String.format(MESSAGE_SUCCESS, profileName)).markProfileSwitched();
     }
 
     @Override
@@ -75,11 +92,5 @@ public class SwitchCommand extends Command {
         assert startsWithData && singleNameFile && endsWithJson : "This file path is not supported";
         String fileName = filePath.getFileName().toString();
         return fileName.substring(0, fileName.length() - 5);
-    }
-
-    public static boolean isValidProfile(String filePath) {
-        String alphanumericWithHyphenRegex = "^[a-zA-Z0-9-]+$";
-        Pattern pattern = Pattern.compile(alphanumericWithHyphenRegex);
-        return filePath.length() <= 10 && pattern.matcher(filePath).matches();
     }
 }

--- a/src/main/java/seedu/address/logic/commands/SwitchCommand.java
+++ b/src/main/java/seedu/address/logic/commands/SwitchCommand.java
@@ -1,0 +1,85 @@
+package seedu.address.logic.commands;
+
+import static java.util.Objects.requireNonNull;
+
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.HashMap;
+import java.util.regex.Pattern;
+
+import seedu.address.logic.commands.exceptions.CommandException;
+import seedu.address.model.AddressBook;
+import seedu.address.model.Model;
+import seedu.address.model.ReadOnlyAddressBook;
+
+public class SwitchCommand extends Command {
+    public static final HashMap<String, ReadOnlyAddressBook> savedProfiles = new HashMap<>();
+    public static final String COMMAND_WORD = "switch";
+    public static final String COMMAND_ALIAS = "s";
+    public static final String MESSAGE_USAGE = COMMAND_WORD
+            + " lorem ipsum blah";
+
+    public static final String MESSAGE_SUCCESS = "Switched to profile %1$s";
+    public static final String MESSAGE_CONSTRAINT = "msg constraint lorem";
+    private final String profileName;
+    public SwitchCommand(String profileName) {
+        this.profileName = profileName;
+    }
+
+    @Override
+    public CommandResult execute(Model model) throws CommandException {
+        requireNonNull(model);
+        Path filePath = Paths.get("data", profileName + ".json");
+
+        //save current profile
+        String curProfileName = getProfileName(model.getAddressBookFilePath());
+        ReadOnlyAddressBook curAddressBook = model.getFrozenAddressBook();
+        savedProfiles.put(curProfileName, curAddressBook);
+
+        //get the new profile
+        ReadOnlyAddressBook nextAddressBook;
+        if (savedProfiles.containsKey(profileName)) {
+            // profile exists
+            nextAddressBook = savedProfiles.get(profileName);
+        } else {
+            nextAddressBook = new AddressBook();
+        }
+
+        // set next profile
+        System.out.println(model.getAddressBookFilePath());
+        model.setAddressBookFilePath(filePath);
+        System.out.println(model.getAddressBookFilePath());
+        model.setAddressBook(nextAddressBook);
+        return new CommandResult(String.format(MESSAGE_SUCCESS, filePath));
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        if (other == this) {
+            return true;
+        }
+
+        // instanceof handles nulls
+        if (!(other instanceof SwitchCommand)) {
+            return false;
+        }
+
+        SwitchCommand otherSwitchCommand = (SwitchCommand) other;
+        return profileName.equals(otherSwitchCommand.profileName);
+    }
+
+    private static String getProfileName(Path filePath) {
+        boolean startsWithData = filePath.startsWith("data");
+        boolean singleNameFile = filePath.getNameCount() == 2;
+        boolean endsWithJson = filePath.toString().endsWith(".json");
+        assert startsWithData && singleNameFile && endsWithJson : "This file path is not supported";
+        String fileName = filePath.getFileName().toString();
+        return fileName.substring(0, fileName.length() - 5);
+    }
+
+    public static boolean isValidProfile(String filePath) {
+        String alphanumericWithHyphenRegex = "^[a-zA-Z0-9-]+$";
+        Pattern pattern = Pattern.compile(alphanumericWithHyphenRegex);
+        return filePath.length() <= 10 && pattern.matcher(filePath).matches();
+    }
+}

--- a/src/main/java/seedu/address/logic/parser/AddressBookParser.java
+++ b/src/main/java/seedu/address/logic/parser/AddressBookParser.java
@@ -102,7 +102,7 @@ public class AddressBookParser {
 
         case ViewCommand.COMMAND_WORD:
             return new ViewCommandParser().parse(arguments);
-         
+
         case SwitchCommand.COMMAND_WORD:
         case SwitchCommand.COMMAND_ALIAS:
             return new SwitchCommandParser().parse(arguments);

--- a/src/main/java/seedu/address/logic/parser/AddressBookParser.java
+++ b/src/main/java/seedu/address/logic/parser/AddressBookParser.java
@@ -17,6 +17,7 @@ import seedu.address.logic.commands.ExitCommand;
 import seedu.address.logic.commands.FindCommand;
 import seedu.address.logic.commands.HelpCommand;
 import seedu.address.logic.commands.ListCommand;
+import seedu.address.logic.commands.SwitchCommand;
 import seedu.address.logic.commands.ViewCommand;
 import seedu.address.logic.parser.exceptions.ParseException;
 
@@ -86,6 +87,9 @@ public class AddressBookParser {
 
         case ViewCommand.COMMAND_WORD:
             return new ViewCommandParser().parse(arguments);
+        case SwitchCommand.COMMAND_WORD:
+        case SwitchCommand.COMMAND_ALIAS:
+            return new SwitchCommandParser().parse(arguments);
 
         default:
             logger.finer("This user input caused a ParseException: " + userInput);

--- a/src/main/java/seedu/address/logic/parser/ParserUtil.java
+++ b/src/main/java/seedu/address/logic/parser/ParserUtil.java
@@ -2,20 +2,18 @@ package seedu.address.logic.parser;
 
 import static java.util.Objects.requireNonNull;
 
-import java.nio.file.Path;
-import java.nio.file.Paths;
 import java.util.Collection;
 import java.util.HashSet;
 import java.util.Set;
 
 import seedu.address.commons.core.index.Index;
 import seedu.address.commons.util.StringUtil;
-import seedu.address.logic.commands.SwitchCommand;
 import seedu.address.logic.parser.exceptions.ParseException;
 import seedu.address.model.person.Email;
 import seedu.address.model.person.Name;
 import seedu.address.model.person.Phone;
 import seedu.address.model.person.Telegram;
+import seedu.address.model.profile.Profile;
 import seedu.address.model.role.Role;
 
 /**
@@ -125,12 +123,15 @@ public class ParserUtil {
         return roleSet;
     }
 
-    public static String parseProfileName(String profileName) throws ParseException {
+    /**
+     * Parses {@code String profile} into a {@code Profile}
+     */
+    public static Profile parseProfileName(String profileName) throws ParseException {
         requireNonNull(profileName);
         String trimmedProfileName = profileName.trim();
-        if (!SwitchCommand.isValidProfile(trimmedProfileName)) {
-            throw new ParseException(SwitchCommand.MESSAGE_CONSTRAINT);
+        if (!Profile.isValidProfile(trimmedProfileName)) {
+            throw new ParseException(Profile.MESSAGE_CONSTRAINTS);
         }
-        return trimmedProfileName;
+        return new Profile(trimmedProfileName);
     }
 }

--- a/src/main/java/seedu/address/logic/parser/ParserUtil.java
+++ b/src/main/java/seedu/address/logic/parser/ParserUtil.java
@@ -2,12 +2,15 @@ package seedu.address.logic.parser;
 
 import static java.util.Objects.requireNonNull;
 
+import java.nio.file.Path;
+import java.nio.file.Paths;
 import java.util.Collection;
 import java.util.HashSet;
 import java.util.Set;
 
 import seedu.address.commons.core.index.Index;
 import seedu.address.commons.util.StringUtil;
+import seedu.address.logic.commands.SwitchCommand;
 import seedu.address.logic.parser.exceptions.ParseException;
 import seedu.address.model.person.Email;
 import seedu.address.model.person.Name;
@@ -120,5 +123,14 @@ public class ParserUtil {
             roleSet.add(parseRole(roleName));
         }
         return roleSet;
+    }
+
+    public static String parseProfileName(String profileName) throws ParseException {
+        requireNonNull(profileName);
+        String trimmedProfileName = profileName.trim();
+        if (!SwitchCommand.isValidProfile(trimmedProfileName)) {
+            throw new ParseException(SwitchCommand.MESSAGE_CONSTRAINT);
+        }
+        return trimmedProfileName;
     }
 }

--- a/src/main/java/seedu/address/logic/parser/SwitchCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/SwitchCommandParser.java
@@ -1,18 +1,29 @@
 package seedu.address.logic.parser;
 
-import static seedu.address.logic.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
-
 import seedu.address.logic.commands.SwitchCommand;
 import seedu.address.logic.parser.exceptions.ParseException;
+import seedu.address.model.profile.Profile;
 
+/**
+ * Parses input arguments and creates a new {@code SwitchCommand} object.
+ */
 public class SwitchCommandParser implements Parser<SwitchCommand> {
+    /**
+     * Parses the given {@code String} of arguments in the context of the {@code SwitchCommand}
+     * and returns a {@code SwitchCommand} object for execution.
+     * If a valid profile name is provided, the command will switch to that profile.
+     * If the input is empty, an {@code EmptyProfile} singleton will be returned.
+     *
+     * @param args The user input representing the profile name.
+     * @return A {@code SwitchCommand} object for execution.
+     * @throws ParseException if the user input is not the expected format.
+     */
     public SwitchCommand parse(String args) throws ParseException {
-        try {
-            String profileName = ParserUtil.parseProfileName(args);
-            return new SwitchCommand(profileName);
-        } catch (ParseException pe) {
-            throw new ParseException(
-                    String.format(MESSAGE_INVALID_COMMAND_FORMAT, SwitchCommand.MESSAGE_USAGE));
+        if (args.isEmpty()) {
+            Profile p = Profile.getEmptyProfile();
+            return new SwitchCommand(p);
         }
+        Profile profileName = ParserUtil.parseProfileName(args.toLowerCase());
+        return new SwitchCommand(profileName);
     }
 }

--- a/src/main/java/seedu/address/logic/parser/SwitchCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/SwitchCommandParser.java
@@ -1,0 +1,18 @@
+package seedu.address.logic.parser;
+
+import static seedu.address.logic.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
+
+import seedu.address.logic.commands.SwitchCommand;
+import seedu.address.logic.parser.exceptions.ParseException;
+
+public class SwitchCommandParser implements Parser<SwitchCommand> {
+    public SwitchCommand parse(String args) throws ParseException {
+        try {
+            String profileName = ParserUtil.parseProfileName(args);
+            return new SwitchCommand(profileName);
+        } catch (ParseException pe) {
+            throw new ParseException(
+                    String.format(MESSAGE_INVALID_COMMAND_FORMAT, SwitchCommand.MESSAGE_USAGE));
+        }
+    }
+}

--- a/src/main/java/seedu/address/model/AddressBook.java
+++ b/src/main/java/seedu/address/model/AddressBook.java
@@ -57,10 +57,6 @@ public class AddressBook implements ReadOnlyAddressBook {
         setPersons(newData.getPersonList());
     }
 
-    public AddressBook copy() {
-        return new AddressBook(this);
-    }
-
     //// person-level operations
 
     /**

--- a/src/main/java/seedu/address/model/AddressBook.java
+++ b/src/main/java/seedu/address/model/AddressBook.java
@@ -57,6 +57,10 @@ public class AddressBook implements ReadOnlyAddressBook {
         setPersons(newData.getPersonList());
     }
 
+    public AddressBook copy() {
+        return new AddressBook(this);
+    }
+
     //// person-level operations
 
     /**

--- a/src/main/java/seedu/address/model/Model.java
+++ b/src/main/java/seedu/address/model/Model.java
@@ -1,11 +1,13 @@
 package seedu.address.model;
 
 import java.nio.file.Path;
+import java.util.HashSet;
 import java.util.function.Predicate;
 
 import javafx.collections.ObservableList;
 import seedu.address.commons.core.GuiSettings;
 import seedu.address.model.person.Person;
+import seedu.address.model.profile.Profile;
 
 /**
  * The API of the Model component.
@@ -45,18 +47,23 @@ public interface Model {
     void setAddressBookFilePath(Path addressBookFilePath);
 
     /**
+     * Returns the set of profiles in the user preference file.
+     */
+    HashSet<Profile> getProfiles();
+
+    /**
+     * Adds a new profile to the user preference file.
+     * @param profileName the new profile to be added.
+     */
+    void addToProfiles(Profile profileName);
+
+    /**
      * Replaces address book data with the data in {@code addressBook}.
      */
     void setAddressBook(ReadOnlyAddressBook addressBook);
 
     /** Returns the AddressBook */
     ReadOnlyAddressBook getAddressBook();
-
-    /**
-     * Return a frozen view of the address book.
-     * @return A copied address book.
-     */
-    ReadOnlyAddressBook getFrozenAddressBook();
 
     /**
      * Returns true if a person with the same identity as {@code person} exists in the address book.

--- a/src/main/java/seedu/address/model/Model.java
+++ b/src/main/java/seedu/address/model/Model.java
@@ -53,6 +53,12 @@ public interface Model {
     ReadOnlyAddressBook getAddressBook();
 
     /**
+     * Return a frozen view of the address book.
+     * @return A copied address book.
+     */
+    ReadOnlyAddressBook getFrozenAddressBook();
+
+    /**
      * Returns true if a person with the same identity as {@code person} exists in the address book.
      */
     boolean hasPerson(Person person);

--- a/src/main/java/seedu/address/model/ModelManager.java
+++ b/src/main/java/seedu/address/model/ModelManager.java
@@ -4,6 +4,7 @@ import static java.util.Objects.requireNonNull;
 import static seedu.address.commons.util.CollectionUtil.requireAllNonNull;
 
 import java.nio.file.Path;
+import java.util.HashSet;
 import java.util.function.Predicate;
 import java.util.logging.Logger;
 
@@ -12,6 +13,7 @@ import javafx.collections.transformation.FilteredList;
 import seedu.address.commons.core.GuiSettings;
 import seedu.address.commons.core.LogsCenter;
 import seedu.address.model.person.Person;
+import seedu.address.model.profile.Profile;
 
 /**
  * Represents the in-memory model of the address book data.
@@ -75,6 +77,16 @@ public class ModelManager implements Model {
         userPrefs.setAddressBookFilePath(addressBookFilePath);
     }
 
+    @Override
+    public HashSet<Profile> getProfiles() {
+        return userPrefs.getProfiles();
+    }
+
+    @Override
+    public void addToProfiles(Profile profileName) {
+        userPrefs.addToProfiles(profileName);
+    }
+
     //=========== AddressBook ================================================================================
 
     @Override
@@ -85,11 +97,6 @@ public class ModelManager implements Model {
     @Override
     public ReadOnlyAddressBook getAddressBook() {
         return addressBook;
-    }
-
-    @Override
-    public ReadOnlyAddressBook getFrozenAddressBook() {
-        return addressBook.copy();
     }
 
     @Override

--- a/src/main/java/seedu/address/model/ModelManager.java
+++ b/src/main/java/seedu/address/model/ModelManager.java
@@ -88,6 +88,11 @@ public class ModelManager implements Model {
     }
 
     @Override
+    public ReadOnlyAddressBook getFrozenAddressBook() {
+        return addressBook.copy();
+    }
+
+    @Override
     public boolean hasPerson(Person person) {
         requireNonNull(person);
         return addressBook.hasPerson(person);

--- a/src/main/java/seedu/address/model/ReadOnlyUserPrefs.java
+++ b/src/main/java/seedu/address/model/ReadOnlyUserPrefs.java
@@ -1,8 +1,10 @@
 package seedu.address.model;
 
 import java.nio.file.Path;
+import java.util.HashSet;
 
 import seedu.address.commons.core.GuiSettings;
+import seedu.address.model.profile.Profile;
 
 /**
  * Unmodifiable view of user prefs.
@@ -13,4 +15,5 @@ public interface ReadOnlyUserPrefs {
 
     Path getAddressBookFilePath();
 
+    HashSet<Profile> getProfiles();
 }

--- a/src/main/java/seedu/address/model/UserPrefs.java
+++ b/src/main/java/seedu/address/model/UserPrefs.java
@@ -4,17 +4,19 @@ import static java.util.Objects.requireNonNull;
 
 import java.nio.file.Path;
 import java.nio.file.Paths;
+import java.util.HashSet;
 import java.util.Objects;
 
 import seedu.address.commons.core.GuiSettings;
+import seedu.address.model.profile.Profile;
 
 /**
  * Represents User's preferences.
  */
 public class UserPrefs implements ReadOnlyUserPrefs {
-
     private GuiSettings guiSettings = new GuiSettings();
     private Path addressBookFilePath = Paths.get("data" , "addressbook.json");
+    private final HashSet<Profile> profiles = new HashSet<>();
 
     /**
      * Creates a {@code UserPrefs} with default values.
@@ -27,6 +29,14 @@ public class UserPrefs implements ReadOnlyUserPrefs {
     public UserPrefs(ReadOnlyUserPrefs userPrefs) {
         this();
         resetData(userPrefs);
+    }
+
+    public HashSet<Profile> getProfiles() {
+        return profiles;
+    }
+
+    public void addToProfiles(Profile profile) {
+        this.profiles.add(profile);
     }
 
     /**
@@ -69,7 +79,8 @@ public class UserPrefs implements ReadOnlyUserPrefs {
 
         UserPrefs otherUserPrefs = (UserPrefs) other;
         return guiSettings.equals(otherUserPrefs.guiSettings)
-                && addressBookFilePath.equals(otherUserPrefs.addressBookFilePath);
+                && addressBookFilePath.equals(otherUserPrefs.addressBookFilePath)
+                && profiles.equals(otherUserPrefs.profiles);
     }
 
     @Override
@@ -82,6 +93,7 @@ public class UserPrefs implements ReadOnlyUserPrefs {
         StringBuilder sb = new StringBuilder();
         sb.append("Gui Settings : " + guiSettings);
         sb.append("\nLocal data file location : " + addressBookFilePath);
+        sb.append("\nProfiles: :" + profiles);
         return sb.toString();
     }
 

--- a/src/main/java/seedu/address/model/profile/Profile.java
+++ b/src/main/java/seedu/address/model/profile/Profile.java
@@ -1,0 +1,104 @@
+package seedu.address.model.profile;
+
+import static java.util.Objects.requireNonNull;
+import static seedu.address.commons.util.AppUtil.checkArgument;
+
+import java.util.regex.Pattern;
+
+/**
+ * Represents a user profile with a name.
+ */
+public class Profile {
+    public static final String MESSAGE_CONSTRAINTS =
+            "The profile name can only contain letters (a-z, A-Z), numbers (0-9), and hyphens (-). "
+                    + "It must also be 30 characters or less.";
+    public static final String VALIDATION_REGEX = "^[a-zA-Z0-9-]+$";
+    public final String profileName;
+
+    /**
+     * Constructs a {@code Profile}.
+     *
+     * @param profileName A valid profile name.
+     */
+    public Profile(String profileName) {
+        requireNonNull(profileName);
+        checkArgument(isValidProfile(profileName), MESSAGE_CONSTRAINTS);
+        this.profileName = profileName;
+    }
+
+    /**
+     * Checks if the given profile name is valid based on the following criteria:
+     * <ul>
+     *     <li>The profile name must be alphanumeric (a-z, A-Z, 0-9) or contain hyphens (-).</li>
+     *     <li>The profile name must not exceed 30 characters in length.</li>
+     * </ul>
+     *
+     * @param profileName the name of the new profile to validate
+     * @return true if the profile name is valid according to the criteria, false otherwise
+     */
+    public static boolean isValidProfile(String profileName) {
+        Pattern pattern = Pattern.compile(VALIDATION_REGEX);
+        return profileName.length() <= 30 && pattern.matcher(profileName).matches();
+    }
+
+    /**
+     * Returns the singleton instance of the {@code EmptyProfile} class.
+     *
+     * @return An instance of {@code EmptyProfile}.
+     */
+    public static EmptyProfile getEmptyProfile() {
+        return EmptyProfile.getInstance();
+    }
+
+    /**
+     * A singleton class that represents an empty profile.
+     */
+    public static class EmptyProfile extends Profile {
+        private static final EmptyProfile instance = new EmptyProfile();
+
+        /**
+         * Constructs an {@code EmptyProfile} with an arbitrary name.
+         */
+        private EmptyProfile() {
+            super("EMPTY");
+        }
+
+        /**
+         * Returns the singleton instance of the {@code EmptyProfile} class.
+         *
+         * @return The single instance of {@code EmptyProfile}.
+         */
+        private static EmptyProfile getInstance() {
+            return instance;
+        }
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        if (other == this) {
+            return true;
+        }
+
+        // instanceof handles nulls
+        if (!(other instanceof Profile)) {
+            return false;
+        }
+
+        Profile otherProfile = (Profile) other;
+        return profileName.equalsIgnoreCase(otherProfile.profileName);
+    }
+
+    @Override
+    public int hashCode() {
+        return profileName.hashCode();
+    }
+
+    /**
+     * Format state as text for viewing.
+     */
+    @Override
+    public String toString() {
+        return profileName;
+    }
+}
+

--- a/src/main/java/seedu/address/storage/AddressBookStorage.java
+++ b/src/main/java/seedu/address/storage/AddressBookStorage.java
@@ -18,6 +18,12 @@ public interface AddressBookStorage {
     Path getAddressBookFilePath();
 
     /**
+     * Updates the path to the data file.
+     * @param filePath the new file path.
+     */
+    void updateAddressBookFilePath(Path filePath);
+
+    /**
      * Returns AddressBook data as a {@link ReadOnlyAddressBook}.
      * Returns {@code Optional.empty()} if storage file is not found.
      *

--- a/src/main/java/seedu/address/storage/JsonAddressBookStorage.java
+++ b/src/main/java/seedu/address/storage/JsonAddressBookStorage.java
@@ -31,6 +31,10 @@ public class JsonAddressBookStorage implements AddressBookStorage {
         return filePath;
     }
 
+    public void updateAddressBookFilePath(Path filePath) {
+        this.filePath = filePath;
+    }
+
     @Override
     public Optional<ReadOnlyAddressBook> readAddressBook() throws DataLoadingException {
         return readAddressBook(filePath);

--- a/src/main/java/seedu/address/storage/Storage.java
+++ b/src/main/java/seedu/address/storage/Storage.java
@@ -24,6 +24,9 @@ public interface Storage extends AddressBookStorage, UserPrefsStorage {
     Path getAddressBookFilePath();
 
     @Override
+    void updateAddressBookFilePath(Path filePath);
+
+    @Override
     Optional<ReadOnlyAddressBook> readAddressBook() throws DataLoadingException;
 
     @Override

--- a/src/main/java/seedu/address/storage/StorageManager.java
+++ b/src/main/java/seedu/address/storage/StorageManager.java
@@ -54,6 +54,11 @@ public class StorageManager implements Storage {
     }
 
     @Override
+    public void updateAddressBookFilePath(Path filePath) {
+        addressBookStorage.updateAddressBookFilePath(filePath);
+    }
+
+    @Override
     public Optional<ReadOnlyAddressBook> readAddressBook() throws DataLoadingException {
         return readAddressBook(addressBookStorage.getAddressBookFilePath());
     }

--- a/src/main/java/seedu/address/ui/MainWindow.java
+++ b/src/main/java/seedu/address/ui/MainWindow.java
@@ -38,6 +38,7 @@ public class MainWindow extends UiPart<Stage> {
     private ResultDisplay resultDisplay;
     private HelpWindow helpWindow;
     private ViewPersonCard viewPersonCard;
+    private StatusBarFooter statusBarFooter;
 
     @FXML
     private VBox personList;
@@ -129,7 +130,7 @@ public class MainWindow extends UiPart<Stage> {
         resultDisplay = new ResultDisplay();
         resultDisplayPlaceholder.getChildren().add(resultDisplay.getRoot());
 
-        StatusBarFooter statusBarFooter = new StatusBarFooter(logic.getAddressBookFilePath());
+        statusBarFooter = new StatusBarFooter(logic.getAddressBookFilePath());
         statusbarPlaceholder.getChildren().add(statusBarFooter.getRoot());
 
         CommandBox commandBox = new CommandBox(this::executeCommand);
@@ -222,6 +223,10 @@ public class MainWindow extends UiPart<Stage> {
 
             if (commandResult.isView()) {
                 openViewPersonCard(commandResult.getViewPerson());
+            }
+
+            if (commandResult.isProfileSwitched()) {
+                statusBarFooter.setSaveLocationStatus(logic.getAddressBookFilePath());
             }
 
             return commandResult;

--- a/src/main/java/seedu/address/ui/StatusBarFooter.java
+++ b/src/main/java/seedu/address/ui/StatusBarFooter.java
@@ -25,4 +25,11 @@ public class StatusBarFooter extends UiPart<Region> {
         saveLocationStatus.setText(Paths.get(".").resolve(saveLocation).toString());
     }
 
+    /**
+     * Update the status bar footer when a profile is switched.
+     * @param saveLocation the data file path that will display on the footer
+     */
+    public void setSaveLocationStatus(Path saveLocation) {
+        saveLocationStatus.setText(Paths.get(".").resolve(saveLocation).toString());
+    }
 }

--- a/src/test/java/seedu/address/logic/commands/AddCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/AddCommandTest.java
@@ -10,6 +10,7 @@ import static seedu.address.testutil.TypicalPersons.ALICE;
 import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.HashSet;
 import java.util.function.Predicate;
 
 import org.junit.jupiter.api.Test;
@@ -23,6 +24,7 @@ import seedu.address.model.Model;
 import seedu.address.model.ReadOnlyAddressBook;
 import seedu.address.model.ReadOnlyUserPrefs;
 import seedu.address.model.person.Person;
+import seedu.address.model.profile.Profile;
 import seedu.address.testutil.PersonBuilder;
 
 public class AddCommandTest {
@@ -115,6 +117,16 @@ public class AddCommandTest {
 
         @Override
         public void setAddressBookFilePath(Path addressBookFilePath) {
+            throw new AssertionError("This method should not be called.");
+        }
+
+        @Override
+        public HashSet<Profile> getProfiles() {
+            throw new AssertionError("This method should not be called.");
+        }
+
+        @Override
+        public void addToProfiles(Profile profileName) {
             throw new AssertionError("This method should not be called.");
         }
 


### PR DESCRIPTION
  Add fully functioning switch command for profile management

  Implement the `SwitchCommand` which:
  - Switches the session to a new profile if a valid profile name is
    provided.
  - Lists all available profiles if no profile name is provided and
    other profiles exist.
  - Prevents switching to the current active profile and notifies
    the user if the requested profile is the same as the active one.

closes #73 