### PR TITLE
Add list contacts with role "Member" command and 

### DIFF
--- a/src/main/java/seedu/address/logic/Messages.java
+++ b/src/main/java/seedu/address/logic/Messages.java
@@ -15,7 +15,7 @@ public class Messages {
     public static final String MESSAGE_UNKNOWN_COMMAND = "Unknown command";
     public static final String MESSAGE_INVALID_COMMAND_FORMAT = "Invalid command format! \n%1$s";
     public static final String MESSAGE_INVALID_PERSON_DISPLAYED_INDEX = "The person index provided is invalid";
-    public static final String MESSAGE_PERSONS_LISTED_OVERVIEW = "%1$d persons listed!";
+    public static final String MESSAGE_PERSONS_LISTED_OVERVIEW = "%1$d people listed!";
     public static final String MESSAGE_DUPLICATE_FIELDS =
                 "Multiple values specified for the following single-valued field(s): ";
 

--- a/src/main/java/seedu/address/logic/Messages.java
+++ b/src/main/java/seedu/address/logic/Messages.java
@@ -18,6 +18,7 @@ public class Messages {
     public static final String MESSAGE_PERSONS_LISTED_OVERVIEW = "%1$d people listed!";
     public static final String MESSAGE_DUPLICATE_FIELDS =
                 "Multiple values specified for the following single-valued field(s): ";
+    public static final String MESSAGE_INVALID_TELEGRAM = "Cannot find person with telegram handle: %1$s";
 
     /**
      * Returns an error message indicating the duplicate prefixes.

--- a/src/main/java/seedu/address/logic/commands/AttendanceMarkingCommand.java
+++ b/src/main/java/seedu/address/logic/commands/AttendanceMarkingCommand.java
@@ -1,0 +1,7 @@
+package seedu.address.logic.commands;
+
+/**
+ * Represents type of command about attendance marking, namely MarkAttendanceCommand and UnmarkAttendanceCommand.
+ */
+public abstract class AttendanceMarkingCommand extends Command {
+}

--- a/src/main/java/seedu/address/logic/commands/EditCommand.java
+++ b/src/main/java/seedu/address/logic/commands/EditCommand.java
@@ -100,11 +100,11 @@ public class EditCommand extends Command {
         Name updatedName = editPersonDescriptor.getName().orElse(personToEdit.getName());
         Phone updatedPhone = editPersonDescriptor.getPhone().orElse(personToEdit.getPhone());
         Email updatedEmail = editPersonDescriptor.getEmail().orElse(personToEdit.getEmail());
-        Telegram updatedAddress = editPersonDescriptor.getTelegram().orElse(personToEdit.getTelegram());
+        Telegram updatedTelegram = editPersonDescriptor.getTelegram().orElse(personToEdit.getTelegram());
         Set<Role> updatedRoles = editPersonDescriptor.getRoles().orElse(personToEdit.getRoles());
         Set<Attendance> attendance = personToEdit.getAttendance();
 
-        return new Person(updatedName, updatedPhone, updatedEmail, updatedAddress, updatedRoles, attendance);
+        return new Person(updatedName, updatedPhone, updatedEmail, updatedTelegram, updatedRoles, attendance);
     }
 
     @Override

--- a/src/main/java/seedu/address/logic/commands/ListAttendanceCommand.java
+++ b/src/main/java/seedu/address/logic/commands/ListAttendanceCommand.java
@@ -9,7 +9,7 @@ import seedu.address.model.person.RoleIsMemberPredicate;
 /**
  * List all members of cca (people with member role) in address book
  */
-public class ListAttendanceCommand extends Command{
+public class ListAttendanceCommand extends Command {
     public static final String COMMAND_WORD = "attendance";
     public static final String COMMAND_ALIAS = "atd";
 

--- a/src/main/java/seedu/address/logic/commands/ListAttendanceCommand.java
+++ b/src/main/java/seedu/address/logic/commands/ListAttendanceCommand.java
@@ -1,0 +1,27 @@
+package seedu.address.logic.commands;
+
+import static java.util.Objects.requireNonNull;
+
+import seedu.address.logic.Messages;
+import seedu.address.model.Model;
+import seedu.address.model.person.RoleIsMemberPredicate;
+
+/**
+ * List all members of cca (people with member role) in address book
+ */
+public class ListAttendanceCommand extends Command{
+    public static final String COMMAND_WORD = "attendance";
+    public static final String COMMAND_ALIAS = "atd";
+
+    private static final RoleIsMemberPredicate memberFilter = new RoleIsMemberPredicate();
+
+    @Override
+    public CommandResult execute(Model model) {
+        requireNonNull(model);
+
+        model.updateFilteredPersonList(memberFilter);
+
+        return new CommandResult(
+                String.format(Messages.MESSAGE_PERSONS_LISTED_OVERVIEW, model.getFilteredPersonList().size()));
+    }
+}

--- a/src/main/java/seedu/address/logic/commands/MarkAttendanceCommand.java
+++ b/src/main/java/seedu/address/logic/commands/MarkAttendanceCommand.java
@@ -33,9 +33,9 @@ public class MarkAttendanceCommand extends AttendanceMarkingCommand {
             + ": Mark the attendance of people with list of input telegrams on designated date.\n"
             + "Parameters: "
             + PREFIX_TELEGRAM + "TELEGRAM "
-            + PREFIX_DATE + "DATE "
-            + "Example: " + COMMAND_WORD + " " + PREFIX_TELEGRAM + "johndoe "
-            + PREFIX_TELEGRAM + "johndog " + PREFIX_DATE + "2024-10-21";
+            + PREFIX_DATE + "DATE \n"
+            + "Example: " + COMMAND_WORD + " " + PREFIX_TELEGRAM + "alexYeoh "
+            + PREFIX_TELEGRAM + "berniceYu " + PREFIX_DATE + "2024-10-21";
 
     public static final String MESSAGE_MARK_PERSON_SUCCESS = "Mark %1$d people's attendance on %2$s.";
 

--- a/src/main/java/seedu/address/logic/commands/MarkAttendanceCommand.java
+++ b/src/main/java/seedu/address/logic/commands/MarkAttendanceCommand.java
@@ -83,7 +83,8 @@ public class MarkAttendanceCommand extends AttendanceMarkingCommand {
         }
 
         MarkAttendanceCommand otherMarkAttendanceCommand = (MarkAttendanceCommand) other;
-        return this.telegrams.equals(otherMarkAttendanceCommand.telegrams) & this.attendance.equals(otherMarkAttendanceCommand.attendance);
+        return this.telegrams.equals(otherMarkAttendanceCommand.telegrams)
+                & this.attendance.equals(otherMarkAttendanceCommand.attendance);
     }
 
     @Override
@@ -119,7 +120,7 @@ public class MarkAttendanceCommand extends AttendanceMarkingCommand {
         Set<Attendance> newAttendanceList = new HashSet<>(person.getAttendance());
         newAttendanceList.add(attendance);
         Name name = person.getName();
-        Phone phone =person.getPhone();
+        Phone phone = person.getPhone();
         Email email = person.getEmail();
         Telegram telegram = person.getTelegram();
         Set<Role> roles = person.getRoles();

--- a/src/main/java/seedu/address/logic/commands/MarkAttendanceCommand.java
+++ b/src/main/java/seedu/address/logic/commands/MarkAttendanceCommand.java
@@ -1,0 +1,137 @@
+package seedu.address.logic.commands;
+
+import static java.util.Objects.requireNonNull;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_DATE;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_TELEGRAM;
+import static seedu.address.model.Model.PREDICATE_SHOW_ALL_PERSONS;
+
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+
+import seedu.address.commons.util.ToStringBuilder;
+import seedu.address.logic.Messages;
+import seedu.address.logic.commands.exceptions.CommandException;
+import seedu.address.model.Model;
+import seedu.address.model.attendance.Attendance;
+import seedu.address.model.person.Email;
+import seedu.address.model.person.Name;
+import seedu.address.model.person.Person;
+import seedu.address.model.person.Phone;
+import seedu.address.model.person.Telegram;
+import seedu.address.model.role.Role;
+
+/**
+ * Mark the attendance of people with targeted telegram handle.
+ */
+public class MarkAttendanceCommand extends AttendanceMarkingCommand {
+    public static final String COMMAND_WORD = "mark";
+    public static final String COMMAND_ALIAS = "m";
+
+    public static final String MESSAGE_USAGE = COMMAND_WORD
+            + ": Mark the attendance of people with list of input telegrams on designated date.\n"
+            + "Parameters: "
+            + PREFIX_TELEGRAM + "TELEGRAM "
+            + PREFIX_DATE + "DATE "
+            + "Example: " + COMMAND_WORD + " " + PREFIX_TELEGRAM + "johndoe "
+            + PREFIX_TELEGRAM + "johndog " + PREFIX_DATE + "2024-10-21";
+
+    public static final String MESSAGE_MARK_PERSON_SUCCESS = "Mark %1$d people's attendance on %2$s.";
+
+    private final List<Telegram> telegrams;
+    private final Attendance attendance;
+
+    /**
+     * Constructs a {@code MarkAttendanceCommand} that marks the attendance
+     * for the owners of the specified telegrams on the given date.
+     *
+     * @param telegrams the list of {@code Telegram} objects representing the people
+     *                  whose attendance will be marked.
+     * @param attendance the {@code Attendance} object representing the date
+     *                   of the attendance to be recorded.
+     */
+    public MarkAttendanceCommand(List<Telegram> telegrams, Attendance attendance) {
+        this.telegrams = telegrams;
+        this.attendance = attendance;
+    }
+
+
+    @Override
+    public CommandResult execute(Model model) throws CommandException {
+        requireNonNull(model);
+        List<Person> lastShownList = model.getFilteredPersonList();
+        List<Person> peopleToMarkAttendance = findByTelegram(telegrams, lastShownList);
+        if (peopleToMarkAttendance.isEmpty()) {
+            throw new CommandException(String.format(Messages.MESSAGE_INVALID_TELEGRAM, telegrams));
+        }
+
+        markAttendance(model, peopleToMarkAttendance, this.attendance);
+        model.updateFilteredPersonList(PREDICATE_SHOW_ALL_PERSONS);
+        return new CommandResult(String.format(MESSAGE_MARK_PERSON_SUCCESS, peopleToMarkAttendance.size(), attendance));
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        if (other == this) {
+            return true;
+        }
+
+        // instanceof handles nulls
+        if (!(other instanceof MarkAttendanceCommand)) {
+            return false;
+        }
+
+        MarkAttendanceCommand otherMarkAttendanceCommand = (MarkAttendanceCommand) other;
+        return this.telegrams.equals(otherMarkAttendanceCommand.telegrams) & this.attendance.equals(otherMarkAttendanceCommand.attendance);
+    }
+
+    @Override
+    public String toString() {
+        return new ToStringBuilder(this)
+                .add("telegrams", telegrams)
+                .add("attendance", attendance)
+                .toString();
+    }
+
+    /**
+     * Find person with target telegram handle in current contact list
+     * @param telegrams Target telegram handle to search in peopleList
+     * @param peopleList All people in current contact list view
+     * @return Person with {@code telegram} if it exists, else return person not found
+     */
+    protected static List<Person> findByTelegram(List<Telegram> telegrams, List<Person> peopleList) {
+        List<Person> peopleToMark = new ArrayList<>();
+        for (Person person: peopleList) {
+            if (telegrams.contains(person.getTelegram())) {
+                peopleToMark.add(person);
+            }
+        }
+        return peopleToMark;
+    }
+
+
+    /**
+     * Creates and returns a {@code Person} with updated attendances that includes the {@code attendance} parameter
+     * The attendance list will automatically keep the same if the added attendance already exists.
+     */
+    private Person addAttendanceToPerson(Person person, Attendance attendance) {
+        Set<Attendance> newAttendanceList = new HashSet<>(person.getAttendance());
+        newAttendanceList.add(attendance);
+        Name name = person.getName();
+        Phone phone =person.getPhone();
+        Email email = person.getEmail();
+        Telegram telegram = person.getTelegram();
+        Set<Role> roles = person.getRoles();
+        Set<Attendance> updatedAttendances = newAttendanceList;
+
+        return new Person(name, phone, email, telegram, roles, updatedAttendances);
+    }
+
+    private void markAttendance(Model model, List<Person> peopleToMark, Attendance attendance) {
+        for (Person p: peopleToMark) {
+            Person markedPerson = addAttendanceToPerson(p, attendance);
+            model.setPerson(p, markedPerson);
+        }
+    }
+}

--- a/src/main/java/seedu/address/logic/commands/UnmarkAttendanceCommand.java
+++ b/src/main/java/seedu/address/logic/commands/UnmarkAttendanceCommand.java
@@ -69,7 +69,8 @@ public class UnmarkAttendanceCommand extends AttendanceMarkingCommand {
 
         unmarkAttendance(model, peopleToMarkAttendance, this.attendance);
         model.updateFilteredPersonList(PREDICATE_SHOW_ALL_PERSONS);
-        return new CommandResult(String.format(MESSAGE_UNMARK_PERSON_SUCCESS, peopleToMarkAttendance.size(), attendance));
+        return new CommandResult(String.format(
+                MESSAGE_UNMARK_PERSON_SUCCESS, peopleToMarkAttendance.size(), attendance));
     }
 
     @Override
@@ -83,7 +84,8 @@ public class UnmarkAttendanceCommand extends AttendanceMarkingCommand {
         }
 
         UnmarkAttendanceCommand otherMarkAttendanceCommand = (UnmarkAttendanceCommand) other;
-        return this.telegrams.equals(otherMarkAttendanceCommand.telegrams) & this.attendance.equals(otherMarkAttendanceCommand.attendance);
+        return this.telegrams.equals(otherMarkAttendanceCommand.telegrams)
+                & this.attendance.equals(otherMarkAttendanceCommand.attendance);
     }
 
     @Override
@@ -103,7 +105,7 @@ public class UnmarkAttendanceCommand extends AttendanceMarkingCommand {
         Set<Attendance> newAttendanceList = new HashSet<>(person.getAttendance());
         newAttendanceList.remove(attendance);
         Name name = person.getName();
-        Phone phone =person.getPhone();
+        Phone phone = person.getPhone();
         Email email = person.getEmail();
         Telegram telegram = person.getTelegram();
         Set<Role> roles = person.getRoles();

--- a/src/main/java/seedu/address/logic/commands/UnmarkAttendanceCommand.java
+++ b/src/main/java/seedu/address/logic/commands/UnmarkAttendanceCommand.java
@@ -1,0 +1,121 @@
+package seedu.address.logic.commands;
+
+import static java.util.Objects.requireNonNull;
+import static seedu.address.logic.commands.MarkAttendanceCommand.findByTelegram;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_DATE;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_TELEGRAM;
+import static seedu.address.model.Model.PREDICATE_SHOW_ALL_PERSONS;
+
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+
+import seedu.address.commons.util.ToStringBuilder;
+import seedu.address.logic.Messages;
+import seedu.address.logic.commands.exceptions.CommandException;
+import seedu.address.model.Model;
+import seedu.address.model.attendance.Attendance;
+import seedu.address.model.person.Email;
+import seedu.address.model.person.Name;
+import seedu.address.model.person.Person;
+import seedu.address.model.person.Phone;
+import seedu.address.model.person.Telegram;
+import seedu.address.model.role.Role;
+
+/**
+ * Unmark the attendance of people with targeted telegram handle.
+ */
+public class UnmarkAttendanceCommand extends AttendanceMarkingCommand {
+    public static final String COMMAND_WORD = "unmark";
+    public static final String COMMAND_ALIAS = "u";
+
+    public static final String MESSAGE_USAGE = COMMAND_WORD
+            + ": Unmark(delete) the attendance of people with list of input telegrams on designated date.\n"
+            + "Parameters: "
+            + PREFIX_TELEGRAM + "TELEGRAM "
+            + PREFIX_DATE + "DATE "
+            + "Example: " + COMMAND_WORD + " " + PREFIX_TELEGRAM + "johndoe "
+            + PREFIX_TELEGRAM + "johndog " + PREFIX_DATE + "2024-10-21";
+
+    public static final String MESSAGE_UNMARK_PERSON_SUCCESS = "Unmark %1$d people's attendance on %2$s.";
+
+    private final List<Telegram> telegrams;
+    private final Attendance attendance;
+
+    /**
+     * Constructs a {@code UnMarkAttendanceCommand} that unmarks (deletes) the attendance
+     * for the owners of the specified telegrams on the given date.
+     *
+     * @param telegrams the list of {@code Telegram} objects representing the people
+     *                  whose attendance will be unmarked.
+     * @param attendance the {@code Attendance} object representing the date
+     *                   of the attendance to be unrecorded.
+     */
+
+    public UnmarkAttendanceCommand(List<Telegram> telegrams, Attendance attendance) {
+        this.telegrams = telegrams;
+        this.attendance = attendance;
+    }
+
+
+    @Override
+    public CommandResult execute(Model model) throws CommandException {
+        requireNonNull(model);
+        List<Person> lastShownList = model.getFilteredPersonList();
+        List<Person> peopleToMarkAttendance = findByTelegram(telegrams, lastShownList);
+        if (peopleToMarkAttendance.isEmpty()) {
+            throw new CommandException(String.format(Messages.MESSAGE_INVALID_TELEGRAM, telegrams));
+        }
+
+        unmarkAttendance(model, peopleToMarkAttendance, this.attendance);
+        model.updateFilteredPersonList(PREDICATE_SHOW_ALL_PERSONS);
+        return new CommandResult(String.format(MESSAGE_UNMARK_PERSON_SUCCESS, peopleToMarkAttendance.size(), attendance));
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        if (other == this) {
+            return true;
+        }
+
+        if (!(other instanceof UnmarkAttendanceCommand)) {
+            return false;
+        }
+
+        UnmarkAttendanceCommand otherMarkAttendanceCommand = (UnmarkAttendanceCommand) other;
+        return this.telegrams.equals(otherMarkAttendanceCommand.telegrams) & this.attendance.equals(otherMarkAttendanceCommand.attendance);
+    }
+
+    @Override
+    public String toString() {
+        return new ToStringBuilder(this)
+                .add("telegrams", telegrams)
+                .add("attendance", attendance)
+                .toString();
+    }
+
+
+    /**
+     * Creates and returns a {@code Person} with the {@code attendance} parameter removed from its attendance list
+     * The attendance list will automatically keep the same if the attendance doesn't exist initially.
+     */
+    private Person removeAttendanceToPerson(Person person, Attendance attendance) {
+        Set<Attendance> newAttendanceList = new HashSet<>(person.getAttendance());
+        newAttendanceList.remove(attendance);
+        Name name = person.getName();
+        Phone phone =person.getPhone();
+        Email email = person.getEmail();
+        Telegram telegram = person.getTelegram();
+        Set<Role> roles = person.getRoles();
+        Set<Attendance> updatedAttendances = newAttendanceList;
+
+        return new Person(name, phone, email, telegram, roles, updatedAttendances);
+    }
+
+    private void unmarkAttendance(Model model, List<Person> peopleToMark, Attendance attendance) {
+        for (Person p: peopleToMark) {
+            Person markedPerson = removeAttendanceToPerson(p, attendance);
+            model.setPerson(p, markedPerson);
+        }
+    }
+}

--- a/src/main/java/seedu/address/logic/commands/UnmarkAttendanceCommand.java
+++ b/src/main/java/seedu/address/logic/commands/UnmarkAttendanceCommand.java
@@ -27,15 +27,15 @@ import seedu.address.model.role.Role;
  */
 public class UnmarkAttendanceCommand extends AttendanceMarkingCommand {
     public static final String COMMAND_WORD = "unmark";
-    public static final String COMMAND_ALIAS = "u";
+    public static final String COMMAND_ALIAS = "um";
 
     public static final String MESSAGE_USAGE = COMMAND_WORD
             + ": Unmark(delete) the attendance of people with list of input telegrams on designated date.\n"
             + "Parameters: "
             + PREFIX_TELEGRAM + "TELEGRAM "
-            + PREFIX_DATE + "DATE "
-            + "Example: " + COMMAND_WORD + " " + PREFIX_TELEGRAM + "johndoe "
-            + PREFIX_TELEGRAM + "johndog " + PREFIX_DATE + "2024-10-21";
+            + PREFIX_DATE + "DATE \n"
+            + "Example: " + COMMAND_WORD + " " + PREFIX_TELEGRAM + "alexYeoh "
+            + PREFIX_TELEGRAM + "berniceYu " + PREFIX_DATE + "2024-10-21";
 
     public static final String MESSAGE_UNMARK_PERSON_SUCCESS = "Unmark %1$d people's attendance on %2$s.";
 

--- a/src/main/java/seedu/address/logic/parser/AddressBookParser.java
+++ b/src/main/java/seedu/address/logic/parser/AddressBookParser.java
@@ -16,6 +16,7 @@ import seedu.address.logic.commands.EditCommand;
 import seedu.address.logic.commands.ExitCommand;
 import seedu.address.logic.commands.FindCommand;
 import seedu.address.logic.commands.HelpCommand;
+import seedu.address.logic.commands.ListAttendanceCommand;
 import seedu.address.logic.commands.ListCommand;
 import seedu.address.logic.commands.ViewCommand;
 import seedu.address.logic.parser.exceptions.ParseException;
@@ -77,6 +78,10 @@ public class AddressBookParser {
         case ListCommand.COMMAND_WORD:
         case ListCommand.COMMAND_ALIAS:
             return new ListCommand();
+
+        case ListAttendanceCommand.COMMAND_WORD:
+        case ListAttendanceCommand.COMMAND_ALIAS:
+            return new ListAttendanceCommand();
 
         case ExitCommand.COMMAND_WORD:
             return new ExitCommand();

--- a/src/main/java/seedu/address/logic/parser/AddressBookParser.java
+++ b/src/main/java/seedu/address/logic/parser/AddressBookParser.java
@@ -18,6 +18,8 @@ import seedu.address.logic.commands.FindCommand;
 import seedu.address.logic.commands.HelpCommand;
 import seedu.address.logic.commands.ListAttendanceCommand;
 import seedu.address.logic.commands.ListCommand;
+import seedu.address.logic.commands.MarkAttendanceCommand;
+import seedu.address.logic.commands.UnmarkAttendanceCommand;
 import seedu.address.logic.commands.ViewCommand;
 import seedu.address.logic.parser.exceptions.ParseException;
 
@@ -82,6 +84,14 @@ public class AddressBookParser {
         case ListAttendanceCommand.COMMAND_WORD:
         case ListAttendanceCommand.COMMAND_ALIAS:
             return new ListAttendanceCommand();
+
+        case MarkAttendanceCommand.COMMAND_WORD:
+        case MarkAttendanceCommand.COMMAND_ALIAS:
+            return new AttendanceMarkingCommandParser(MarkAttendanceCommand.COMMAND_WORD).parse(arguments);
+
+        case UnmarkAttendanceCommand.COMMAND_WORD:
+        case UnmarkAttendanceCommand.COMMAND_ALIAS:
+            return new AttendanceMarkingCommandParser(UnmarkAttendanceCommand.COMMAND_WORD).parse(arguments);
 
         case ExitCommand.COMMAND_WORD:
             return new ExitCommand();

--- a/src/main/java/seedu/address/logic/parser/AttendanceMarkingCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/AttendanceMarkingCommandParser.java
@@ -19,7 +19,7 @@ import seedu.address.model.person.Telegram;
  */
 public class AttendanceMarkingCommandParser implements Parser<AttendanceMarkingCommand> {
     private String markType;
-    public  AttendanceMarkingCommandParser(String markType) {
+    public AttendanceMarkingCommandParser(String markType) {
         this.markType = markType;
     }
 
@@ -35,9 +35,11 @@ public class AttendanceMarkingCommandParser implements Parser<AttendanceMarkingC
         if (!arePrefixesPresent(argumentMultimap, PREFIX_TELEGRAM, PREFIX_DATE)
                 || !argumentMultimap.getPreamble().isEmpty()) {
             if (markType.equals(MarkAttendanceCommand.COMMAND_WORD)) {
-                throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, MarkAttendanceCommand.MESSAGE_USAGE));
+                throw new ParseException(String.format(
+                        MESSAGE_INVALID_COMMAND_FORMAT, MarkAttendanceCommand.MESSAGE_USAGE));
             } else {
-                throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, UnmarkAttendanceCommand.MESSAGE_USAGE));
+                throw new ParseException(String.format(
+                        MESSAGE_INVALID_COMMAND_FORMAT, UnmarkAttendanceCommand.MESSAGE_USAGE));
             }
         }
         List<String> telegramKeywords = argumentMultimap.getAllValues(PREFIX_TELEGRAM);
@@ -47,7 +49,8 @@ public class AttendanceMarkingCommandParser implements Parser<AttendanceMarkingC
         boolean hasEmptyInput = telegramKeywords.stream().anyMatch(str -> str.trim().isEmpty());
 
         if (hasEmptyInput) {
-            throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, MarkAttendanceCommand.MESSAGE_USAGE));
+            throw new ParseException(String.format(
+                    MESSAGE_INVALID_COMMAND_FORMAT, MarkAttendanceCommand.MESSAGE_USAGE));
         }
 
         List<Telegram> telegrams = telegramKeywords.stream().map(String::trim).map(Telegram::new).toList();

--- a/src/main/java/seedu/address/logic/parser/AttendanceMarkingCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/AttendanceMarkingCommandParser.java
@@ -1,0 +1,70 @@
+package seedu.address.logic.parser;
+
+import static seedu.address.logic.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_DATE;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_TELEGRAM;
+
+import java.util.List;
+import java.util.stream.Stream;
+
+import seedu.address.logic.commands.AttendanceMarkingCommand;
+import seedu.address.logic.commands.MarkAttendanceCommand;
+import seedu.address.logic.commands.UnmarkAttendanceCommand;
+import seedu.address.logic.parser.exceptions.ParseException;
+import seedu.address.model.attendance.Attendance;
+import seedu.address.model.person.Telegram;
+
+/**
+ * Parses input arguments and creates a new MarkAttendanceCommand or UnmarkAttendance object based on user input
+ */
+public class AttendanceMarkingCommandParser implements Parser<AttendanceMarkingCommand> {
+    private String markType;
+    public  AttendanceMarkingCommandParser(String markType) {
+        this.markType = markType;
+    }
+
+    /**
+     * Parses the given {@code String} of arguments in the context of the MarkAttendanceCommand or
+     * UnmarkAttendanceCommand based on {@code markType}
+     * and returns a MarkAttendanceCommand or UnmarkAttendanceCommand object for execution.
+     * @throws ParseException if the user input does not conform the expected format
+     */
+    public AttendanceMarkingCommand parse(String args) throws ParseException {
+        ArgumentMultimap argumentMultimap = ArgumentTokenizer.tokenize(args, PREFIX_TELEGRAM, PREFIX_DATE);
+
+        if (!arePrefixesPresent(argumentMultimap, PREFIX_TELEGRAM, PREFIX_DATE)
+                || !argumentMultimap.getPreamble().isEmpty()) {
+            if (markType.equals(MarkAttendanceCommand.COMMAND_WORD)) {
+                throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, MarkAttendanceCommand.MESSAGE_USAGE));
+            } else {
+                throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, UnmarkAttendanceCommand.MESSAGE_USAGE));
+            }
+        }
+        List<String> telegramKeywords = argumentMultimap.getAllValues(PREFIX_TELEGRAM);
+        Attendance attendance = ParserUtil.parseAttendance(argumentMultimap.getValue(PREFIX_DATE).get());
+
+
+        boolean hasEmptyInput = telegramKeywords.stream().anyMatch(str -> str.trim().isEmpty());
+
+        if (hasEmptyInput) {
+            throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, MarkAttendanceCommand.MESSAGE_USAGE));
+        }
+
+        List<Telegram> telegrams = telegramKeywords.stream().map(String::trim).map(Telegram::new).toList();
+
+        if (markType.equals(MarkAttendanceCommand.COMMAND_WORD)) {
+            return new MarkAttendanceCommand(telegrams, attendance);
+        } else {
+            return new UnmarkAttendanceCommand(telegrams, attendance);
+        }
+    }
+
+    /**
+     * Returns true if none of the prefixes contains empty {@code Optional} values in the given
+     * {@code ArgumentMultimap}.
+     */
+    private static boolean arePrefixesPresent(ArgumentMultimap argumentMultimap, Prefix... prefixes) {
+        return Stream.of(prefixes).allMatch(prefix -> argumentMultimap.getValue(prefix).isPresent());
+    }
+
+}

--- a/src/main/java/seedu/address/logic/parser/CliSyntax.java
+++ b/src/main/java/seedu/address/logic/parser/CliSyntax.java
@@ -11,5 +11,6 @@ public class CliSyntax {
     public static final Prefix PREFIX_EMAIL = new Prefix("e/");
     public static final Prefix PREFIX_TELEGRAM = new Prefix("t/");
     public static final Prefix PREFIX_ROLE = new Prefix("r/");
+    public static final Prefix PREFIX_DATE = new Prefix("d/");
 
 }

--- a/src/main/java/seedu/address/logic/parser/ParserUtil.java
+++ b/src/main/java/seedu/address/logic/parser/ParserUtil.java
@@ -13,6 +13,7 @@ import seedu.address.model.person.Email;
 import seedu.address.model.person.Name;
 import seedu.address.model.person.Phone;
 import seedu.address.model.person.Telegram;
+import seedu.address.model.role.Member;
 import seedu.address.model.role.Role;
 
 /**
@@ -106,6 +107,9 @@ public class ParserUtil {
         String trimmedRole = role.trim();
         if (!Role.isValidRoleName(trimmedRole)) {
             throw new ParseException(Role.MESSAGE_CONSTRAINTS);
+        }
+        if (trimmedRole.toLowerCase().equals(Member.MEMBER_ROLE.toLowerCase())) {
+            return new Member();
         }
         return new Role(trimmedRole);
     }

--- a/src/main/java/seedu/address/logic/parser/ParserUtil.java
+++ b/src/main/java/seedu/address/logic/parser/ParserUtil.java
@@ -9,6 +9,7 @@ import java.util.Set;
 import seedu.address.commons.core.index.Index;
 import seedu.address.commons.util.StringUtil;
 import seedu.address.logic.parser.exceptions.ParseException;
+import seedu.address.model.attendance.Attendance;
 import seedu.address.model.person.Email;
 import seedu.address.model.person.Name;
 import seedu.address.model.person.Phone;
@@ -94,6 +95,21 @@ public class ParserUtil {
             throw new ParseException(Email.MESSAGE_CONSTRAINTS);
         }
         return new Email(trimmedEmail);
+    }
+
+    /**
+     * Parses a {@code String dateString} into an {@code Attendance}.
+     * Leading and trailing whitespaces will be trimmed.
+     *
+     * @throws ParseException if the given {@code date} is invalid.
+     */
+    public static Attendance parseAttendance(String dateString) throws ParseException {
+        requireNonNull(dateString);
+        String trimmedDateString = dateString.trim();
+        if (!Attendance.isValidDate(trimmedDateString)) {
+            throw new ParseException(Attendance.MESSAGE_CONSTRAINTS);
+        }
+        return new Attendance(trimmedDateString);
     }
 
     /**

--- a/src/main/java/seedu/address/model/attendance/Attendance.java
+++ b/src/main/java/seedu/address/model/attendance/Attendance.java
@@ -6,6 +6,8 @@ import static seedu.address.commons.util.AppUtil.checkArgument;
 import java.time.LocalDate;
 import java.time.format.DateTimeParseException;
 
+import seedu.address.model.person.Person;
+
 /**
  * Represents an Attendance session for a contact in the address book.
  * Guarantees: immutable; session is valid as declared in {@link #isValidDate(String)}

--- a/src/main/java/seedu/address/model/attendance/Attendance.java
+++ b/src/main/java/seedu/address/model/attendance/Attendance.java
@@ -6,8 +6,6 @@ import static seedu.address.commons.util.AppUtil.checkArgument;
 import java.time.LocalDate;
 import java.time.format.DateTimeParseException;
 
-import seedu.address.model.person.Person;
-
 /**
  * Represents an Attendance session for a contact in the address book.
  * Guarantees: immutable; session is valid as declared in {@link #isValidDate(String)}

--- a/src/main/java/seedu/address/model/person/RoleIsMemberPredicate.java
+++ b/src/main/java/seedu/address/model/person/RoleIsMemberPredicate.java
@@ -1,0 +1,32 @@
+package seedu.address.model.person;
+
+import java.util.function.Predicate;
+
+import seedu.address.commons.util.ToStringBuilder;
+import seedu.address.model.role.Member;
+
+public class RoleIsMemberPredicate implements Predicate<Person> {
+
+    @Override
+    public boolean test(Person person) {
+        return person.getRoles().stream().anyMatch(x -> x.equals(new Member()));
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        if (other == this) {
+            return true;
+        }
+
+        // instanceof handles nulls
+        if (!(other instanceof RoleIsMemberPredicate)) {
+            return false;
+        }
+        return true;
+    }
+
+    @Override
+    public String toString() {
+        return new ToStringBuilder(this).add("keywords", Member.MEMBER_ROLE).toString();
+    }
+}

--- a/src/main/java/seedu/address/model/person/RoleIsMemberPredicate.java
+++ b/src/main/java/seedu/address/model/person/RoleIsMemberPredicate.java
@@ -5,6 +5,9 @@ import java.util.function.Predicate;
 import seedu.address.commons.util.ToStringBuilder;
 import seedu.address.model.role.Member;
 
+/**
+ * Tests that a {@code Person}'s {@code Role} includes {@code Member}.
+ */
 public class RoleIsMemberPredicate implements Predicate<Person> {
 
     @Override
@@ -18,7 +21,6 @@ public class RoleIsMemberPredicate implements Predicate<Person> {
             return true;
         }
 
-        // instanceof handles nulls
         if (!(other instanceof RoleIsMemberPredicate)) {
             return false;
         }

--- a/src/main/java/seedu/address/model/role/Member.java
+++ b/src/main/java/seedu/address/model/role/Member.java
@@ -4,8 +4,8 @@ package seedu.address.model.role;
  * Member represents a special Role in address book.
  * Guarantees: immutable; name is always "Member".
  */
-public class Member extends Role{
-    public static String MEMBER_ROLE = "Member";
+public class Member extends Role {
+    public static final String MEMBER_ROLE = "Member";
     public Member() {
         super(MEMBER_ROLE);
     }

--- a/src/main/java/seedu/address/model/role/Member.java
+++ b/src/main/java/seedu/address/model/role/Member.java
@@ -1,0 +1,30 @@
+package seedu.address.model.role;
+
+/**
+ * Member represents a special Role in address book.
+ * Guarantees: immutable; name is always "Member".
+ */
+public class Member extends Role{
+    public static String MEMBER_ROLE = "Member";
+    public Member() {
+        super(MEMBER_ROLE);
+    }
+
+    /**
+     * Check if other role is a member.
+     * @param other
+     * @return true if other is an instance of Member or an instance of Role with Member keyword
+     */
+    @Override
+    public boolean equals(Object other) {
+        if (other == this) {
+            return true;
+        } else if (other instanceof Member) {
+            return true;
+        } else if (other instanceof Role) {
+            Role otherRole = (Role) other;
+            return otherRole.equals(new Role(MEMBER_ROLE));
+        }
+        return false;
+    }
+}

--- a/src/main/java/seedu/address/storage/JsonAdaptedRole.java
+++ b/src/main/java/seedu/address/storage/JsonAdaptedRole.java
@@ -4,6 +4,7 @@ import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
 
 import seedu.address.commons.exceptions.IllegalValueException;
+import seedu.address.model.role.Member;
 import seedu.address.model.role.Role;
 
 /**
@@ -41,6 +42,9 @@ class JsonAdaptedRole {
     public Role toModelType() throws IllegalValueException {
         if (!Role.isValidRoleName(roleName)) {
             throw new IllegalValueException(Role.MESSAGE_CONSTRAINTS);
+        }
+        if (roleName.equals(Member.MEMBER_ROLE)) {
+            return new Member();
         }
         return new Role(roleName);
     }


### PR DESCRIPTION
Fixes #80 

## List Member
Extract `Member` as a subclass of `Role`, a `Member` object is same as a `Role` object with keyword "member".
Command: `attendance` or `atd` as alias

## Mark Attendance Commands
Allow mark attendance for multiple telegrams.
**Mark Attendance example**: `mark t/johndoe t/johndog t/mary d/2024-10-22` (alias keyword is `m`)
**Mark Attendance example**: `unmark t/johndoe t/johndog t/mary d/2024-10-22` (alias keyword is `u`)

It's ok if current attendance to mark already exists / current attendance to delete doesn't exist.

## TODO
Currently the UI can't show attendance record of each contacts but show their role instead, need to changed by people taking care of view.
![image](https://github.com/user-attachments/assets/f4ca92ec-2349-444e-ba2f-a491a09ebee6)
