### PR TITLE
Add Sort Command

### DIFF
--- a/src/main/java/seedu/address/commons/core/SortOrder.java
+++ b/src/main/java/seedu/address/commons/core/SortOrder.java
@@ -1,0 +1,23 @@
+package seedu.address.commons.core;
+
+public enum SortOrder {
+    ASC("asc", "ascending"),
+    DESC("desc", "descending"),
+    OG("og", "original");
+
+    public static final String MESSAGE_CONSTRAINTS =
+            "Sort order parameter can only be asc or desc or og.";
+
+    public final String keyword;
+    private final String stringRep;
+
+    private SortOrder(String keyword, String stringRep) {
+        this.keyword = keyword;
+        this.stringRep = stringRep;
+    }
+
+    @Override
+    public String toString() {
+        return this.stringRep;
+    }
+}

--- a/src/main/java/seedu/address/commons/core/SortOrder.java
+++ b/src/main/java/seedu/address/commons/core/SortOrder.java
@@ -1,5 +1,8 @@
 package seedu.address.commons.core;
 
+/**
+ * Enumeration of the possible orderings that the user can sort by
+ */
 public enum SortOrder {
     ASC("asc", "ascending"),
     DESC("desc", "descending"),
@@ -11,7 +14,10 @@ public enum SortOrder {
     public final String keyword;
     private final String stringRep;
 
-    private SortOrder(String keyword, String stringRep) {
+    /**
+     * Creates the relevant enum values with the appropriate {@code keyword} and {@code stringRep}
+     */
+    SortOrder(String keyword, String stringRep) {
         this.keyword = keyword;
         this.stringRep = stringRep;
     }

--- a/src/main/java/seedu/address/logic/Logic.java
+++ b/src/main/java/seedu/address/logic/Logic.java
@@ -33,6 +33,9 @@ public interface Logic {
     /** Returns an unmodifiable view of the filtered list of persons */
     ObservableList<Person> getFilteredPersonList();
 
+    /** Returns an unmodifiable view of the sorted list of persons */
+    ObservableList<Person> getSortedPersonList();
+
     /**
      * Returns the user prefs' address book file path.
      */

--- a/src/main/java/seedu/address/logic/LogicManager.java
+++ b/src/main/java/seedu/address/logic/LogicManager.java
@@ -77,6 +77,11 @@ public class LogicManager implements Logic {
     }
 
     @Override
+    public ObservableList<Person> getSortedPersonList() {
+        return model.getSortedPersonList();
+    }
+
+    @Override
     public Path getAddressBookFilePath() {
         return model.getAddressBookFilePath();
     }

--- a/src/main/java/seedu/address/logic/commands/AddCommand.java
+++ b/src/main/java/seedu/address/logic/commands/AddCommand.java
@@ -21,7 +21,7 @@ public class AddCommand extends Command {
     public static final String COMMAND_WORD = "add";
     public static final String COMMAND_ALIAS = "a";
 
-    public static final String MESSAGE_USAGE = COMMAND_WORD + ": Adds a person to the address book. "
+    public static final String MESSAGE_USAGE = COMMAND_WORD + ": Adds a person to the address book.\n"
             + "Parameters: "
             + PREFIX_NAME + "NAME "
             + PREFIX_PHONE + "PHONE "

--- a/src/main/java/seedu/address/logic/commands/DeleteCommand.java
+++ b/src/main/java/seedu/address/logic/commands/DeleteCommand.java
@@ -35,7 +35,7 @@ public class DeleteCommand extends Command {
     @Override
     public CommandResult execute(Model model) throws CommandException {
         requireNonNull(model);
-        List<Person> lastShownList = model.getFilteredPersonList();
+        List<Person> lastShownList = model.getSortedPersonList();
 
         if (targetIndex.getZeroBased() >= lastShownList.size()) {
             throw new CommandException(Messages.MESSAGE_INVALID_PERSON_DISPLAYED_INDEX);

--- a/src/main/java/seedu/address/logic/commands/EditCommand.java
+++ b/src/main/java/seedu/address/logic/commands/EditCommand.java
@@ -72,7 +72,7 @@ public class EditCommand extends Command {
     @Override
     public CommandResult execute(Model model) throws CommandException {
         requireNonNull(model);
-        List<Person> lastShownList = model.getFilteredPersonList();
+        List<Person> lastShownList = model.getSortedPersonList();
 
         if (index.getZeroBased() >= lastShownList.size()) {
             throw new CommandException(Messages.MESSAGE_INVALID_PERSON_DISPLAYED_INDEX);

--- a/src/main/java/seedu/address/logic/commands/SortCommand.java
+++ b/src/main/java/seedu/address/logic/commands/SortCommand.java
@@ -1,13 +1,13 @@
 package seedu.address.logic.commands;
 
+import static java.util.Objects.requireNonNull;
+
+import java.util.Comparator;
+
 import seedu.address.commons.core.SortOrder;
 import seedu.address.logic.commands.exceptions.CommandException;
 import seedu.address.model.Model;
 import seedu.address.model.person.Person;
-
-import java.util.Comparator;
-
-import static java.util.Objects.requireNonNull;
 
 /**
  * Sorts the currently filtered list of Persons in a user-determined order
@@ -37,11 +37,11 @@ public class SortCommand extends Command {
     public CommandResult execute(Model model) throws CommandException {
         requireNonNull(model);
         if (order == SortOrder.ASC) {
-            model.updateSortedPersonListComparator(Comparator.comparing(
-                    (Person p) -> p.getName().toString()));
+            model.updateSortedPersonListComparator(Comparator.comparing((Person p) ->
+                    p.getName().toString()));
         } else if (order == SortOrder.DESC) {
-            model.updateSortedPersonListComparator(Comparator.comparing(
-                    (Person p) -> p.getName().toString()).reversed());
+            model.updateSortedPersonListComparator(Comparator.comparing((Person p) ->
+                    p.getName().toString()).reversed());
         } else if (order == SortOrder.OG) {
             model.setSortedListToDefault();
         } else {

--- a/src/main/java/seedu/address/logic/commands/SortCommand.java
+++ b/src/main/java/seedu/address/logic/commands/SortCommand.java
@@ -1,0 +1,59 @@
+package seedu.address.logic.commands;
+
+import seedu.address.commons.core.SortOrder;
+import seedu.address.logic.commands.exceptions.CommandException;
+import seedu.address.model.Model;
+import seedu.address.model.person.Person;
+
+import java.util.Comparator;
+
+import static java.util.Objects.requireNonNull;
+
+public class SortCommand extends Command {
+    public static final String COMMAND_WORD = "sort";
+    public static final String COMMAND_ALIAS = "so";
+
+    public static final String MESSAGE_USAGE = COMMAND_WORD + ": Sorts the list of contacts "
+            + "by ascending/descending/original order, based on their names.\n"
+            + "Parameters: [asc/desc/og]\n"
+            + "Example: " + COMMAND_WORD + " asc";
+
+    public static final String MESSAGE_SUCCESS = "Sorted list in %s order";
+
+    private final SortOrder order;
+
+    public SortCommand(SortOrder order) {
+        requireNonNull(order);
+        this.order = order;
+    }
+
+    @Override
+    public CommandResult execute(Model model) throws CommandException {
+        requireNonNull(model);
+        if (order == SortOrder.ASC) {
+            model.updateSortedPersonListComparator(Comparator.comparing(
+                    (Person p) -> p.getName().toString()));
+        } else if (order == SortOrder.DESC) {
+            model.updateSortedPersonListComparator(Comparator.comparing(
+                    (Person p) -> p.getName().toString()).reversed());
+        } else if (order == SortOrder.OG) {
+            model.setSortedListToDefault();
+        } else {
+            throw new CommandException("Invalid arguments"); // this should not happen ever
+        }
+        return new CommandResult(String.format(MESSAGE_SUCCESS, order));
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        if (other == this) {
+            return true;
+        }
+
+        if (!(other instanceof SortCommand otherSortCommand)) {
+            return false;
+        }
+
+        return order == otherSortCommand.order;
+    }
+}

--- a/src/main/java/seedu/address/logic/commands/SortCommand.java
+++ b/src/main/java/seedu/address/logic/commands/SortCommand.java
@@ -9,6 +9,9 @@ import java.util.Comparator;
 
 import static java.util.Objects.requireNonNull;
 
+/**
+ * Sorts the currently filtered list of Persons in a user-determined order
+ */
 public class SortCommand extends Command {
     public static final String COMMAND_WORD = "sort";
     public static final String COMMAND_ALIAS = "so";
@@ -22,6 +25,9 @@ public class SortCommand extends Command {
 
     private final SortOrder order;
 
+    /**
+     * Creates a SortCommand to sort the list of Persons in the specified {@code order}
+     */
     public SortCommand(SortOrder order) {
         requireNonNull(order);
         this.order = order;

--- a/src/main/java/seedu/address/logic/parser/AddressBookParser.java
+++ b/src/main/java/seedu/address/logic/parser/AddressBookParser.java
@@ -19,6 +19,7 @@ import seedu.address.logic.commands.HelpCommand;
 import seedu.address.logic.commands.ListAttendanceCommand;
 import seedu.address.logic.commands.ListCommand;
 import seedu.address.logic.commands.MarkAttendanceCommand;
+import seedu.address.logic.commands.SortCommand;
 import seedu.address.logic.commands.SwitchCommand;
 import seedu.address.logic.commands.UnmarkAttendanceCommand;
 import seedu.address.logic.commands.ViewCommand;
@@ -106,6 +107,10 @@ public class AddressBookParser {
         case SwitchCommand.COMMAND_WORD:
         case SwitchCommand.COMMAND_ALIAS:
             return new SwitchCommandParser().parse(arguments);
+
+        case SortCommand.COMMAND_WORD:
+        case SortCommand.COMMAND_ALIAS:
+            return new SortCommandParser().parse(arguments);
 
         default:
             logger.finer("This user input caused a ParseException: " + userInput);

--- a/src/main/java/seedu/address/logic/parser/ParserUtil.java
+++ b/src/main/java/seedu/address/logic/parser/ParserUtil.java
@@ -157,7 +157,7 @@ public class ParserUtil {
     }
 
     /**
-     * Parses {@code}
+     * Parses {@code order} into an appropriate {@code SortOrder}
      */
     public static SortOrder parseSortOrder(String order) throws ParseException {
         requireNonNull(order);

--- a/src/main/java/seedu/address/logic/parser/ParserUtil.java
+++ b/src/main/java/seedu/address/logic/parser/ParserUtil.java
@@ -6,6 +6,7 @@ import java.util.Collection;
 import java.util.HashSet;
 import java.util.Set;
 
+import seedu.address.commons.core.SortOrder;
 import seedu.address.commons.core.index.Index;
 import seedu.address.commons.util.StringUtil;
 import seedu.address.logic.parser.exceptions.ParseException;
@@ -153,5 +154,19 @@ public class ParserUtil {
             throw new ParseException(Profile.MESSAGE_CONSTRAINTS);
         }
         return new Profile(trimmedProfileName);
+    }
+
+    /**
+     * Parses {@code}
+     */
+    public static SortOrder parseSortOrder(String order) throws ParseException {
+        requireNonNull(order);
+        String trimmedOrder = order.trim();
+        for (SortOrder s : SortOrder.values()) {
+            if (trimmedOrder.equals(s.keyword)) {
+                return s;
+            }
+        }
+        throw new ParseException(SortOrder.MESSAGE_CONSTRAINTS);
     }
 }

--- a/src/main/java/seedu/address/logic/parser/SortCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/SortCommandParser.java
@@ -1,10 +1,10 @@
 package seedu.address.logic.parser;
 
+import static seedu.address.logic.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
+
 import seedu.address.commons.core.SortOrder;
 import seedu.address.logic.commands.SortCommand;
 import seedu.address.logic.parser.exceptions.ParseException;
-
-import static seedu.address.logic.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
 
 /**
  * Parses input arguments and creates a SortCommand object

--- a/src/main/java/seedu/address/logic/parser/SortCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/SortCommandParser.java
@@ -1,0 +1,19 @@
+package seedu.address.logic.parser;
+
+import seedu.address.commons.core.SortOrder;
+import seedu.address.logic.commands.SortCommand;
+import seedu.address.logic.parser.exceptions.ParseException;
+
+import static seedu.address.logic.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
+
+public class SortCommandParser implements Parser<SortCommand> {
+
+    public SortCommand parse(String args) throws ParseException {
+        if (args.isEmpty()) {
+            throw new ParseException(
+                    String.format(MESSAGE_INVALID_COMMAND_FORMAT, SortCommand.MESSAGE_USAGE));
+        }
+        SortOrder s = ParserUtil.parseSortOrder(args);
+        return new SortCommand(s);
+    }
+}

--- a/src/main/java/seedu/address/logic/parser/SortCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/SortCommandParser.java
@@ -6,8 +6,16 @@ import seedu.address.logic.parser.exceptions.ParseException;
 
 import static seedu.address.logic.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
 
+/**
+ * Parses input arguments and creates a SortCommand object
+ */
 public class SortCommandParser implements Parser<SortCommand> {
 
+    /**
+     * Parses the given {@code String} of arguments in the context of the SortCommand
+     * and returns an SortCommand object for execution.
+     * @throws ParseException if the user input does not conform the expected format
+     */
     public SortCommand parse(String args) throws ParseException {
         if (args.isEmpty()) {
             throw new ParseException(

--- a/src/main/java/seedu/address/model/Model.java
+++ b/src/main/java/seedu/address/model/Model.java
@@ -1,6 +1,7 @@
 package seedu.address.model;
 
 import java.nio.file.Path;
+import java.util.Comparator;
 import java.util.HashSet;
 import java.util.function.Predicate;
 
@@ -97,4 +98,17 @@ public interface Model {
      * @throws NullPointerException if {@code predicate} is null.
      */
     void updateFilteredPersonList(Predicate<Person> predicate);
+
+    /** Returns an unmodifiable view of the sorted person list */
+    ObservableList<Person> getSortedPersonList();
+
+    /**
+     * Updates the comparator property of the sorted person list to sort
+     */
+    void updateSortedPersonListComparator(Comparator<Person> comparator);
+
+    /**
+     * Updates the sorted list to be back to the initial ordering
+     */
+    void setSortedListToDefault();
 }

--- a/src/main/java/seedu/address/model/ModelManager.java
+++ b/src/main/java/seedu/address/model/ModelManager.java
@@ -4,12 +4,14 @@ import static java.util.Objects.requireNonNull;
 import static seedu.address.commons.util.CollectionUtil.requireAllNonNull;
 
 import java.nio.file.Path;
+import java.util.Comparator;
 import java.util.HashSet;
 import java.util.function.Predicate;
 import java.util.logging.Logger;
 
 import javafx.collections.ObservableList;
 import javafx.collections.transformation.FilteredList;
+import javafx.collections.transformation.SortedList;
 import seedu.address.commons.core.GuiSettings;
 import seedu.address.commons.core.LogsCenter;
 import seedu.address.model.person.Person;
@@ -24,6 +26,7 @@ public class ModelManager implements Model {
     private final AddressBook addressBook;
     private final UserPrefs userPrefs;
     private final FilteredList<Person> filteredPersons;
+    private final SortedList<Person> sortedPersons;
 
     /**
      * Initializes a ModelManager with the given addressBook and userPrefs.
@@ -36,6 +39,7 @@ public class ModelManager implements Model {
         this.addressBook = new AddressBook(addressBook);
         this.userPrefs = new UserPrefs(userPrefs);
         filteredPersons = new FilteredList<>(this.addressBook.getPersonList());
+        sortedPersons = new SortedList<>(filteredPersons);
     }
 
     public ModelManager() {
@@ -138,6 +142,23 @@ public class ModelManager implements Model {
     public void updateFilteredPersonList(Predicate<Person> predicate) {
         requireNonNull(predicate);
         filteredPersons.setPredicate(predicate);
+    }
+
+    //=========== Sorted Person List Accessors ===============================================================
+    @Override
+    public ObservableList<Person> getSortedPersonList() {
+        return sortedPersons;
+    }
+
+    @Override
+    public void updateSortedPersonListComparator(Comparator<Person> comparator) {
+        requireNonNull(comparator);
+        sortedPersons.setComparator(comparator);
+    }
+
+    @Override
+    public void setSortedListToDefault() {
+        sortedPersons.setComparator(null);
     }
 
     @Override

--- a/src/main/java/seedu/address/ui/MainWindow.java
+++ b/src/main/java/seedu/address/ui/MainWindow.java
@@ -124,7 +124,8 @@ public class MainWindow extends UiPart<Stage> {
      * Fills up all the placeholders of this window.
      */
     void fillInnerParts() {
-        personListPanel = new PersonListPanel(logic.getFilteredPersonList());
+        // personListPanel = new PersonListPanel(logic.getFilteredPersonList());
+        personListPanel = new PersonListPanel(logic.getSortedPersonList());
         personListPanelPlaceholder.getChildren().add(personListPanel.getRoot());
 
         resultDisplay = new ResultDisplay();

--- a/src/test/java/seedu/address/commons/core/SortOrderTest.java
+++ b/src/test/java/seedu/address/commons/core/SortOrderTest.java
@@ -1,2 +1,21 @@
-package seedu.address.commons.core;public class SortOrderTest {
+package seedu.address.commons.core;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import org.junit.jupiter.api.Test;
+
+public class SortOrderTest {
+    @Test
+    public void checkValidStringRepresentations() {
+        assertEquals(SortOrder.ASC.toString(), "ascending");
+        assertEquals(SortOrder.DESC.toString(), "descending");
+        assertEquals(SortOrder.OG.toString(), "original");
+    }
+
+    @Test
+    public void checkValidKeywords() {
+        assertEquals(SortOrder.ASC.keyword, "asc");
+        assertEquals(SortOrder.DESC.keyword, "desc");
+        assertEquals(SortOrder.OG.keyword, "og");
+    }
 }

--- a/src/test/java/seedu/address/commons/core/SortOrderTest.java
+++ b/src/test/java/seedu/address/commons/core/SortOrderTest.java
@@ -1,0 +1,2 @@
+package seedu.address.commons.core;public class SortOrderTest {
+}

--- a/src/test/java/seedu/address/logic/commands/AddCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/AddCommandTest.java
@@ -10,6 +10,7 @@ import static seedu.address.testutil.TypicalPersons.ALICE;
 import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Comparator;
 import java.util.HashSet;
 import java.util.function.Predicate;
 
@@ -167,6 +168,21 @@ public class AddCommandTest {
 
         @Override
         public void updateFilteredPersonList(Predicate<Person> predicate) {
+            throw new AssertionError("This method should not be called.");
+        }
+
+        @Override
+        public ObservableList<Person> getSortedPersonList() {
+            throw new AssertionError("This method should not be called.");
+        }
+
+        @Override
+        public void updateSortedPersonListComparator(Comparator<Person> comparator) {
+            throw new AssertionError("This method should not be called.");
+        }
+
+        @Override
+        public void setSortedListToDefault() {
             throw new AssertionError("This method should not be called.");
         }
     }

--- a/src/test/java/seedu/address/logic/commands/SortCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/SortCommandTest.java
@@ -1,2 +1,71 @@
-package seedu.address.logic.commands;public class SortCommandTest {
+package seedu.address.logic.commands;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.util.Arrays;
+import java.util.List;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import seedu.address.commons.core.SortOrder;
+import seedu.address.logic.commands.exceptions.CommandException;
+import seedu.address.model.Model;
+import seedu.address.model.ModelManager;
+import seedu.address.model.person.Person;
+import seedu.address.testutil.PersonBuilder;
+
+class SortCommandTest {
+    private static final Person A = new PersonBuilder().withName("Alice").withTelegram("a").build();
+    private static final Person B = new PersonBuilder().withName("Bob").withTelegram("b").build();
+    private static final Person C = new PersonBuilder().withName("Charlie").withTelegram("c").build();
+    private static final Person D = new PersonBuilder().withName("David").withTelegram("d").build();
+
+    private Model model;
+
+    private final List<Person> personsAscending = Arrays.asList(A, B, C, D);
+
+    private final List<Person> personsDescending = Arrays.asList(D, C, B, A);
+
+    private final List<Person> personsUnordered = Arrays.asList(B, D, A, C);
+
+    @BeforeEach
+    void setUp() {
+        model = new ModelManager();
+        // Populate the model with some test data
+        for (Person person : personsUnordered) {
+            model.addPerson(person);
+        }
+    }
+
+    @Test
+    void execute_sortAscending_success() throws CommandException {
+        SortCommand sortCommand = new SortCommand(SortOrder.ASC);
+        CommandResult result = sortCommand.execute(model);
+
+        assertEquals(String.format(SortCommand.MESSAGE_SUCCESS, SortOrder.ASC), result.getFeedbackToUser());
+        List<Person> sortedPersons = model.getSortedPersonList();
+        assertEquals(personsAscending, sortedPersons.stream().toList());
+    }
+
+    @Test
+    void execute_sortDescending_success() throws CommandException {
+        SortCommand sortCommand = new SortCommand(SortOrder.DESC);
+        CommandResult result = sortCommand.execute(model);
+
+        assertEquals(String.format(SortCommand.MESSAGE_SUCCESS, SortOrder.DESC), result.getFeedbackToUser());
+        List<Person> sortedPersons = model.getSortedPersonList();
+
+        assertEquals(personsDescending, sortedPersons.stream().toList());
+    }
+
+    @Test
+    void execute_sortOriginal_success() throws CommandException {
+        SortCommand sortCommand = new SortCommand(SortOrder.OG);
+        CommandResult result = sortCommand.execute(model);
+
+        assertEquals(String.format(SortCommand.MESSAGE_SUCCESS, SortOrder.OG), result.getFeedbackToUser());
+        List<Person> sortedPersons = model.getSortedPersonList();
+        assertEquals(personsUnordered, sortedPersons);
+    }
 }

--- a/src/test/java/seedu/address/logic/commands/SortCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/SortCommandTest.java
@@ -1,0 +1,2 @@
+package seedu.address.logic.commands;public class SortCommandTest {
+}

--- a/src/test/java/seedu/address/logic/parser/ParserUtilTest.java
+++ b/src/test/java/seedu/address/logic/parser/ParserUtilTest.java
@@ -13,6 +13,7 @@ import java.util.Set;
 
 import org.junit.jupiter.api.Test;
 
+import seedu.address.commons.core.SortOrder;
 import seedu.address.logic.parser.exceptions.ParseException;
 import seedu.address.model.person.Email;
 import seedu.address.model.person.Name;
@@ -36,6 +37,11 @@ public class ParserUtilTest {
 
     private static final String WHITESPACE = " \t\r\n";
 
+    private static final String ASCENDING = "asc";
+    private static final String DESCENDING = "desc";
+    private static final String ORIGINAL = "og";
+    private static final String INVALID_ORDER = "invalid";
+
     @Test
     public void parseIndex_invalidInput_throwsParseException() {
         assertThrows(ParseException.class, () -> ParserUtil.parseIndex("10 a"));
@@ -44,7 +50,7 @@ public class ParserUtilTest {
     @Test
     public void parseIndex_outOfRangeInput_throwsParseException() {
         assertThrows(ParseException.class, MESSAGE_INVALID_INDEX, ()
-            -> ParserUtil.parseIndex(Long.toString(Integer.MAX_VALUE + 1)));
+                -> ParserUtil.parseIndex(Long.toString(Integer.MAX_VALUE + 1)));
     }
 
     @Test
@@ -192,5 +198,22 @@ public class ParserUtilTest {
         Set<Role> expectedRoleSet = new HashSet<Role>(Arrays.asList(new Role(VALID_ROLE_1), new Role(VALID_ROLE_2)));
 
         assertEquals(expectedRoleSet, actualRoleSet);
+    }
+
+    @Test
+    public void parseSortOrder_null_throwsNullPointerException() {
+        assertThrows(NullPointerException.class, () -> ParserUtil.parseSortOrder(null));
+    }
+
+    @Test
+    public void parseSortOrder_validValue_returnsSortOrder() throws Exception {
+        assertEquals(SortOrder.ASC, ParserUtil.parseSortOrder(ASCENDING));
+        assertEquals(SortOrder.DESC, ParserUtil.parseSortOrder(DESCENDING));
+        assertEquals(SortOrder.OG, ParserUtil.parseSortOrder(ORIGINAL));
+    }
+
+    @Test
+    public void parseSortOrder_invalidValue_throwsParseException() {
+        assertThrows(ParseException.class, () -> ParserUtil.parseSortOrder(INVALID_ORDER));
     }
 }


### PR DESCRIPTION
Fixes #91 

Implements the following:
- `sort asc` to sort currently filtered list by name, in ascending order
- `sort desc` to sort currently filtered list by name, in descending order
- `sort og` to reset the filtered list back to initial ordering (order by creation sequence)

Sorting accommodates filtering and commands that use indices, such as edit and delete

Adds a few test cases to check the sorting functionality