### PR TITLE
Refactor Help Command to display updated guides

### DIFF
--- a/src/main/java/seedu/address/logic/commands/AddCommand.java
+++ b/src/main/java/seedu/address/logic/commands/AddCommand.java
@@ -28,15 +28,15 @@ public class AddCommand extends Command {
             + PREFIX_PHONE + "PHONE "
             + PREFIX_EMAIL + "EMAIL "
             + PREFIX_TELEGRAM + "TELEGRAM "
-            + "Optional: " + PREFIX_FAVOURITE
-            + "[" + PREFIX_ROLE + "ROLE]...\n"
+            + "[" + PREFIX_ROLE + "ROLE] "
+            + "[" + PREFIX_FAVOURITE + "]\n"
             + "Example: " + COMMAND_WORD + " "
             + PREFIX_NAME + "John Doe "
             + PREFIX_PHONE + "98765432 "
             + PREFIX_EMAIL + "johnd@example.com "
             + PREFIX_TELEGRAM + "johnDoe12 "
-            + PREFIX_FAVOURITE
-            + PREFIX_ROLE + "Exco Member";
+            + PREFIX_ROLE + "Exco Member "
+            + PREFIX_FAVOURITE;
 
     public static final String MESSAGE_SUCCESS = "New person added: %1$s";
     public static final String MESSAGE_DUPLICATE_PERSON = "This person already exists in the address book";

--- a/src/main/java/seedu/address/logic/commands/ClearCommand.java
+++ b/src/main/java/seedu/address/logic/commands/ClearCommand.java
@@ -13,6 +13,10 @@ public class ClearCommand extends Command {
     public static final String COMMAND_WORD = "clear";
     public static final String COMMAND_ALIAS = "c";
     public static final String MESSAGE_SUCCESS = "Address book has been cleared!";
+    public static final String MESSAGE_USAGE = COMMAND_WORD
+            + ": Clears all contacts from the system.\n"
+            + "Parameters: None\n"
+            + "Example: " + COMMAND_WORD;
 
 
     @Override

--- a/src/main/java/seedu/address/logic/commands/EditCommand.java
+++ b/src/main/java/seedu/address/logic/commands/EditCommand.java
@@ -41,18 +41,18 @@ public class EditCommand extends Command {
     public static final String COMMAND_ALIAS = "e";
 
     public static final String MESSAGE_USAGE = COMMAND_WORD + ": Edits the details of the person identified "
-            + "by the index number used in the displayed person list. "
+            + "by the index number in the displayed person list. "
             + "Existing values will be overwritten by the input values.\n"
             + "Parameters: INDEX (must be a positive integer) "
             + "[" + PREFIX_NAME + "NAME] "
             + "[" + PREFIX_PHONE + "PHONE] "
             + "[" + PREFIX_EMAIL + "EMAIL] "
             + "[" + PREFIX_TELEGRAM + "TELEGRAM] "
-            + "[" + PREFIX_ROLE + "ROLE]...\n"
-            + "[" + PREFIX_FAVOURITE + " or " + PREFIX_NONFAVOURITE + " (NOT BOTH) ]"
+            + "[" + PREFIX_ROLE + "ROLE] "
+            + "[" + PREFIX_FAVOURITE + " or " + PREFIX_NONFAVOURITE + " (NOT BOTH)]\n"
             + "Example: " + COMMAND_WORD + " 1 "
             + PREFIX_PHONE + "91234567 "
-            + PREFIX_EMAIL + "johndoe@example.com"
+            + PREFIX_EMAIL + "johndoe@example.com "
             + PREFIX_FAVOURITE;
 
     public static final String MESSAGE_EDIT_PERSON_SUCCESS = "Edited Person: %1$s";

--- a/src/main/java/seedu/address/logic/commands/ExitCommand.java
+++ b/src/main/java/seedu/address/logic/commands/ExitCommand.java
@@ -8,7 +8,7 @@ import seedu.address.model.Model;
 public class ExitCommand extends Command {
     public static final String COMMAND_WORD = "exit";
     public static final String MESSAGE_EXIT_ACKNOWLEDGEMENT = "Exiting Address Book as requested ...";
-    public static final String MESSAGE_USAGE = COMMAND_WORD + ": Exits the application\n"
+    public static final String MESSAGE_USAGE = COMMAND_WORD + ": Exits the application.\n"
             + "Parameters: None\n"
             + "Example: " + COMMAND_WORD;
 

--- a/src/main/java/seedu/address/logic/commands/ExitCommand.java
+++ b/src/main/java/seedu/address/logic/commands/ExitCommand.java
@@ -6,10 +6,11 @@ import seedu.address.model.Model;
  * Terminates the program.
  */
 public class ExitCommand extends Command {
-
     public static final String COMMAND_WORD = "exit";
-
     public static final String MESSAGE_EXIT_ACKNOWLEDGEMENT = "Exiting Address Book as requested ...";
+    public static final String MESSAGE_USAGE = COMMAND_WORD + ": Exits the application\n"
+            + "Parameters: None\n"
+            + "Example: " + COMMAND_WORD;
 
     @Override
     public CommandResult execute(Model model) {

--- a/src/main/java/seedu/address/logic/commands/FindCommand.java
+++ b/src/main/java/seedu/address/logic/commands/FindCommand.java
@@ -20,9 +20,9 @@ public class FindCommand extends Command {
     public static final String COMMAND_ALIAS = "f";
 
     public static final String MESSAGE_USAGE = COMMAND_WORD + ": Finds all persons whose names contain any of "
-            + "the specified keywords (case-insensitive) and displays them as a list with index numbers.\n"
+            + "the specified keywords (case-insensitive).\n"
             + "Parameters: [n/nameKeyword] [r/roleKeyword] [t/telegramKeyword] [f/] ...\n"
-            + "Example: " + COMMAND_WORD + " n/alice tan n/bob r/member n/charlie t/ccharliee";
+            + "Example: " + COMMAND_WORD + " n/bernice yu n/charlotte r/member t/davidLi";
 
     private final NameContainsKeywordsPredicate namePredicate;
 

--- a/src/main/java/seedu/address/logic/commands/HelpCommand.java
+++ b/src/main/java/seedu/address/logic/commands/HelpCommand.java
@@ -11,7 +11,7 @@ public class HelpCommand extends Command {
 
     public static final String MESSAGE_USAGE = COMMAND_WORD
             + ": Displays a summary of all commands available in the system.\n"
-            + "Parameters: None"
+            + "Parameters: None\n"
             + "Example: " + COMMAND_WORD;
 
     public static final String SHOWING_HELP_MESSAGE = "Opened help window.";

--- a/src/main/java/seedu/address/logic/commands/HelpCommand.java
+++ b/src/main/java/seedu/address/logic/commands/HelpCommand.java
@@ -9,7 +9,9 @@ public class HelpCommand extends Command {
 
     public static final String COMMAND_WORD = "help";
 
-    public static final String MESSAGE_USAGE = COMMAND_WORD + ": Shows program usage instructions.\n"
+    public static final String MESSAGE_USAGE = COMMAND_WORD
+            + ": Displays a summary of all commands available in the system.\n"
+            + "Parameters: None"
             + "Example: " + COMMAND_WORD;
 
     public static final String SHOWING_HELP_MESSAGE = "Opened help window.";

--- a/src/main/java/seedu/address/logic/commands/ListAttendanceCommand.java
+++ b/src/main/java/seedu/address/logic/commands/ListAttendanceCommand.java
@@ -12,6 +12,7 @@ import seedu.address.model.person.RoleIsMemberPredicate;
 public class ListAttendanceCommand extends Command {
     public static final String COMMAND_WORD = "attendance";
     public static final String COMMAND_ALIAS = "atd";
+    public static final String MESSAGE_USAGE = "TODO ATTENDANCE USAGE";
 
     private static final RoleIsMemberPredicate memberFilter = new RoleIsMemberPredicate();
 

--- a/src/main/java/seedu/address/logic/commands/ListAttendanceCommand.java
+++ b/src/main/java/seedu/address/logic/commands/ListAttendanceCommand.java
@@ -13,7 +13,7 @@ public class ListAttendanceCommand extends Command {
     public static final String COMMAND_WORD = "attendance";
     public static final String COMMAND_ALIAS = "atd";
     public static final String MESSAGE_USAGE = COMMAND_WORD
-            + ": Lists all members of the cca in the system\n"
+            + ": Lists all members of the cca in the system.\n"
             + "Parameters: None\n"
             + "Example: " + COMMAND_WORD;
 

--- a/src/main/java/seedu/address/logic/commands/ListAttendanceCommand.java
+++ b/src/main/java/seedu/address/logic/commands/ListAttendanceCommand.java
@@ -7,12 +7,15 @@ import seedu.address.model.Model;
 import seedu.address.model.person.RoleIsMemberPredicate;
 
 /**
- * List all members of cca (people with member role) in address book
+ * Lists all members of the cca (people with member role) in address book
  */
 public class ListAttendanceCommand extends Command {
     public static final String COMMAND_WORD = "attendance";
     public static final String COMMAND_ALIAS = "atd";
-    public static final String MESSAGE_USAGE = "TODO ATTENDANCE USAGE";
+    public static final String MESSAGE_USAGE = COMMAND_WORD
+            + ": Lists all members of the cca in the system\n"
+            + "Parameters: None\n"
+            + "Example: " + COMMAND_WORD;
 
     private static final RoleIsMemberPredicate memberFilter = new RoleIsMemberPredicate();
 

--- a/src/main/java/seedu/address/logic/commands/ListCommand.java
+++ b/src/main/java/seedu/address/logic/commands/ListCommand.java
@@ -9,12 +9,13 @@ import seedu.address.model.Model;
  * Lists all persons in the address book to the user.
  */
 public class ListCommand extends Command {
-
     public static final String COMMAND_WORD = "list";
     public static final String COMMAND_ALIAS = "l";
-
     public static final String MESSAGE_SUCCESS = "Listed all persons";
-
+    public static final String MESSAGE_USAGE = COMMAND_WORD
+            + ": Lists all contacts in the system"
+            + "Parameters: None"
+            + "Example: " + COMMAND_WORD;
 
     @Override
     public CommandResult execute(Model model) {

--- a/src/main/java/seedu/address/logic/commands/ListCommand.java
+++ b/src/main/java/seedu/address/logic/commands/ListCommand.java
@@ -13,7 +13,7 @@ public class ListCommand extends Command {
     public static final String COMMAND_ALIAS = "l";
     public static final String MESSAGE_SUCCESS = "Listed all persons";
     public static final String MESSAGE_USAGE = COMMAND_WORD
-            + ": Lists all personnel in the system\n"
+            + ": Lists all personnel in the system.\n"
             + "Parameters: None\n"
             + "Example: " + COMMAND_WORD;
 

--- a/src/main/java/seedu/address/logic/commands/ListCommand.java
+++ b/src/main/java/seedu/address/logic/commands/ListCommand.java
@@ -13,8 +13,8 @@ public class ListCommand extends Command {
     public static final String COMMAND_ALIAS = "l";
     public static final String MESSAGE_SUCCESS = "Listed all persons";
     public static final String MESSAGE_USAGE = COMMAND_WORD
-            + ": Lists all contacts in the system"
-            + "Parameters: None"
+            + ": Lists all personnel in the system\n"
+            + "Parameters: None\n"
             + "Example: " + COMMAND_WORD;
 
     @Override

--- a/src/main/java/seedu/address/logic/commands/SwitchCommand.java
+++ b/src/main/java/seedu/address/logic/commands/SwitchCommand.java
@@ -22,11 +22,10 @@ import seedu.address.model.profile.Profile;
  */
 public class SwitchCommand extends Command {
     public static final String COMMAND_WORD = "switch";
-    public static final String COMMAND_ALIAS = "s";
+    public static final String COMMAND_ALIAS = "sw";
     public static final String MESSAGE_USAGE = COMMAND_WORD
             + ": Switches to a different profile based on the provided name.\n"
             + "Parameters: PROFILE_NAME\n"
-            + Profile.MESSAGE_CONSTRAINTS + "\n"
             + "Example: " + COMMAND_WORD + " john-doe";
     public static final String MESSAGE_SUCCESS = "Switched to the profile '%1$s'";
     public static final String MESSAGE_SHOW_PROFILES = "Other profiles: %1$s";

--- a/src/main/java/seedu/address/logic/commands/ViewCommand.java
+++ b/src/main/java/seedu/address/logic/commands/ViewCommand.java
@@ -25,7 +25,7 @@ public class ViewCommand extends Command {
             + ": Finds one contact whose telegram handle "
             + "matches the specified telegram handle (case-insensitive) and displays a new page which "
             + "contains all the contact's information.\n"
-            + "Parameters: TELEGRAM_HANDLE \n"
+            + "Parameters: t/TELEGRAM_HANDLE \n"
             + "Example: " + COMMAND_WORD + " t/TELEGRAM_HANDLE";
 
     private final String tele;

--- a/src/main/java/seedu/address/ui/HelpWindow.java
+++ b/src/main/java/seedu/address/ui/HelpWindow.java
@@ -9,49 +9,64 @@ import javafx.scene.input.Clipboard;
 import javafx.scene.input.ClipboardContent;
 import javafx.stage.Stage;
 import seedu.address.commons.core.LogsCenter;
+import seedu.address.logic.commands.AddCommand;
+import seedu.address.logic.commands.ClearCommand;
+import seedu.address.logic.commands.DeleteCommand;
+import seedu.address.logic.commands.EditCommand;
+import seedu.address.logic.commands.ExitCommand;
+import seedu.address.logic.commands.FindCommand;
+import seedu.address.logic.commands.HelpCommand;
+import seedu.address.logic.commands.ListAttendanceCommand;
+import seedu.address.logic.commands.ListCommand;
+import seedu.address.logic.commands.MarkAttendanceCommand;
+import seedu.address.logic.commands.SortCommand;
+import seedu.address.logic.commands.SwitchCommand;
+import seedu.address.logic.commands.UnmarkAttendanceCommand;
+import seedu.address.logic.commands.ViewCommand;
 
 /**
  * Controller for a help page.
  */
 public class HelpWindow extends UiPart<Stage> {
-
     public static final String USERGUIDE_URL = "https://se-education.org/addressbook-level3/UserGuide.html";
     public static final String HELP_MESSAGE = "Copy the link for the complete user guide  ---> ";
-
-    public static final String HELP_USAGE = "===============================\n"
-            + "         Quick Command Summary\n"
-            + "===============================\n"
-            + "1. Help\n"
-            + "   Displays help information.\n"
-            + "   Format: help\n\n"
-            + "2. Add a Person\n"
-            + "   Adds a new contact to the record.\n"
-            + "   Format: add n/NAME p/PHONE e/EMAIL t/TELEGRAM r/ROLE ([f/])\n\n"
-            + "3. List All Persons\n"
-            + "   Displays all contacts.\n"
-            + "   Format: list\n\n"
-            + "4. Edit a Person\n"
-            + "   Edits an existing contact by index.\n"
-            + "   Format: edit INDEX [n/NAME] [p/PHONE] [e/EMAIL] [t/TELEGRAM] [r/ROLE] ([f/] / [nf/])\n\n"
-            + "5. Find by Name or Role or Telegram or Favourites\n"
-            + "   Finds contacts whose names, roles or telegram contain the specified keywords or\n"
-            + "   if they are marked as favourites.\n"
-            + "   Format: find [n/NAME] [r/ROLE] [t/TELEGRAM] [f/]\n\n"
-            + "6. View contact by telegram handle\n"
-            + "   View detailed information of a contact with the specified telegram handle\n"
-            + "   Format: view t/TELEGRAM\n\n"
-            + "7. Delete a Person\n"
-            + "   Deletes a contact by index.\n"
-            + "   Format: delete INDEX\n\n"
-            + "8. Clear All Entries\n"
-            + "   Clears all contacts from the address book.\n"
-            + "   Format: clear\n\n"
-            + "9. Exit\n"
-            + "   Exits the application.\n"
-            + "   Format: exit";
-
+    public static final String HELP_USAGE;
     private static final Logger logger = LogsCenter.getLogger(HelpWindow.class);
     private static final String FXML = "HelpWindow.fxml";
+    private static final String[] commandMessageUsages = {
+        AddCommand.MESSAGE_USAGE,
+        ClearCommand.MESSAGE_USAGE,
+        DeleteCommand.MESSAGE_USAGE,
+        EditCommand.MESSAGE_USAGE,
+        ExitCommand.MESSAGE_USAGE,
+        FindCommand.MESSAGE_USAGE,
+        HelpCommand.MESSAGE_USAGE,
+        ListAttendanceCommand.MESSAGE_USAGE,
+        ListCommand.MESSAGE_USAGE,
+        MarkAttendanceCommand.MESSAGE_USAGE,
+        SortCommand.MESSAGE_USAGE,
+        SwitchCommand.MESSAGE_USAGE,
+        UnmarkAttendanceCommand.MESSAGE_USAGE,
+        ViewCommand.MESSAGE_USAGE
+    };
+
+    static {
+        StringBuilder helpMessageBuilder = new StringBuilder("""
+                ===============================
+                Command Summary
+                ===============================
+                """);
+        for (int i = 0; i < commandMessageUsages.length; i++) {
+            String[] parts = commandMessageUsages[i].split(":", 2);
+            helpMessageBuilder.append(String.format("%d. %s:\n", i + 1, parts[0].trim()));
+            if (parts.length > 1) {
+                helpMessageBuilder.append("\t").append(parts[1].trim().replace("\n", "\n\t")).append("\n\n");
+            } else {
+                helpMessageBuilder.append("\n");
+            }
+        }
+        HELP_USAGE = helpMessageBuilder.toString();
+    }
 
     @FXML
     private Button copyButton;
@@ -71,6 +86,8 @@ public class HelpWindow extends UiPart<Stage> {
         super(FXML, root);
         helpMessage.setText(HELP_MESSAGE);
         helpUsage.setText(HELP_USAGE);
+        root.setMinWidth(600);
+        root.setMinHeight(400);
     }
 
     /**

--- a/src/main/resources/view/HelpWindow.fxml
+++ b/src/main/resources/view/HelpWindow.fxml
@@ -11,7 +11,7 @@
 <?import javafx.scene.layout.VBox?>
 <?import javafx.scene.Scene?>
 <?import javafx.stage.Stage?>
-<fx:root resizable="false" title="Help" type="javafx.stage.Stage" xmlns="http://javafx.com/javafx/17" xmlns:fx="http://javafx.com/fxml/1">
+<fx:root title="Help" type="javafx.stage.Stage" xmlns="http://javafx.com/javafx/17" xmlns:fx="http://javafx.com/fxml/1">
   <icons>
     <Image url="@/images/help_icon.png" />
   </icons>
@@ -24,7 +24,7 @@
 
       <HBox alignment="CENTER" fx:id="helpMessageContainer">
         <children>
-          <ScrollPane fitToWidth="true" prefWidth="700" prefHeight="600" focusTraversable="true">
+          <ScrollPane HBox.hgrow="ALWAYS" fitToWidth="true" prefWidth="700" prefHeight="600" focusTraversable="true">
             <VBox>
               <HBox spacing="10" alignment="CENTER_LEFT">
                 <Label fx:id="helpMessage" text="Label">


### PR DESCRIPTION
The current help command uses hard-coded help messages for each command in the system.

This approach causes frequent inconsistencies when commands are added or modified, as the help messages are not synchronized.

Refactor the help command to use the MESSAGE_USAGE string from each command, ensuring that the help information remains consistent and up-to-date.

Minor adjustments are made to some Command classes to ensure uniform message formatting across the system. Also, minor visual improvements were made to the help window for better user experience.

closes #97 