### PR TITLE
Fix Alpha bugs for `attendance` `mark` and `unmark`

### DIFF
--- a/src/main/java/seedu/address/logic/Messages.java
+++ b/src/main/java/seedu/address/logic/Messages.java
@@ -16,10 +16,14 @@ public class Messages {
     public static final String MESSAGE_INVALID_COMMAND_FORMAT = "Invalid command format! \n%1$s";
     public static final String MESSAGE_INVALID_PERSON_DISPLAYED_INDEX = "The person index provided is invalid";
     public static final String MESSAGE_PERSONS_LISTED_OVERVIEW = "%1$d people listed!";
+    public static final String MESSAGE_MEMBERS_LISTED_OVERVIEW = "%1$d Member(s) listed!";
     public static final String MESSAGE_DUPLICATE_FIELDS =
                 "Multiple values specified for the following single-valued field(s): ";
-    public static final String MESSAGE_INVALID_TELEGRAM = "Cannot find person with telegram handle: %1$s";
-
+    public static final String MESSAGE_INVALID_TELEGRAM = "Cannot find member(s) with telegram handle: %1$s";
+    public static final String MESSAGE_NONMEMBER_ATTENDANCE =
+            "Cannot mark attendance for contact that is not a member. "
+                    + "Remove non-member contact from the list and try again.";
+    public static final String MESSAGE_NO_ADDITIONAL_PARAMS = "Warning: %1$s command takes in no additional parameters";
     /**
      * Returns an error message indicating the duplicate prefixes.
      */

--- a/src/main/java/seedu/address/logic/commands/ListAttendanceCommand.java
+++ b/src/main/java/seedu/address/logic/commands/ListAttendanceCommand.java
@@ -26,6 +26,6 @@ public class ListAttendanceCommand extends Command {
         model.updateFilteredPersonList(memberFilter);
 
         return new CommandResult(
-                String.format(Messages.MESSAGE_PERSONS_LISTED_OVERVIEW, model.getFilteredPersonList().size()));
+                String.format(Messages.MESSAGE_MEMBERS_LISTED_OVERVIEW, model.getFilteredPersonList().size()));
     }
 }

--- a/src/main/java/seedu/address/logic/commands/MarkAttendanceCommand.java
+++ b/src/main/java/seedu/address/logic/commands/MarkAttendanceCommand.java
@@ -115,7 +115,7 @@ public class MarkAttendanceCommand extends AttendanceMarkingCommand {
      * Find person with target telegram handle in current contact list
      * @param telegrams Target telegram handle to search in peopleList
      * @param peopleList All people in current contact list view
-     *      Add member to {@code membersToMarkAttendance} if their telegram handles is in input list;
+     *      Add members to {@code membersToMarkAttendance} if their telegram handles are in input list;
      *      add telegram handles that don't map to a member to {@code unmatchedTelegrams}
      *      Set {@code membersToMarkAttendance} and {@code unmatchedTelegrams} to object private variables accordingly.
      */

--- a/src/main/java/seedu/address/logic/commands/MarkAttendanceCommand.java
+++ b/src/main/java/seedu/address/logic/commands/MarkAttendanceCommand.java
@@ -1,6 +1,7 @@
 package seedu.address.logic.commands;
 
 import static java.util.Objects.requireNonNull;
+import static seedu.address.logic.Messages.MESSAGE_NONMEMBER_ATTENDANCE;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_DATE;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_TELEGRAM;
 import static seedu.address.model.Model.PREDICATE_SHOW_ALL_PERSONS;
@@ -31,18 +32,24 @@ public class MarkAttendanceCommand extends AttendanceMarkingCommand {
     public static final String COMMAND_ALIAS = "m";
 
     public static final String MESSAGE_USAGE = COMMAND_WORD
-            + ": Mark the attendance of people with list of input telegrams on designated date.\n"
+            + ": Mark the attendance of member(s) within list of input telegrams on designated date.\n"
             + "Parameters: "
             + PREFIX_TELEGRAM + "TELEGRAM "
             + PREFIX_DATE + "DATE \n"
             + "Example: " + COMMAND_WORD + " " + PREFIX_TELEGRAM + "alexYeoh "
             + PREFIX_TELEGRAM + "berniceYu " + PREFIX_DATE + "2024-10-21";
 
-    public static final String MESSAGE_MARK_PERSON_SUCCESS =
-            "Successfully mark the attendance on %1$s for these people: %2$s";
+    public static final String MESSAGE_MARK_MEMBER_SUCCESS =
+            "Successfully mark the attendance on %1$s for member(s): %2$s";
+    public static final String MESSAGE_CONTAIN_MARKED_MEMBER =
+            "Please note that attendance of %1$s is already marked.";
 
     private final List<Telegram> telegrams;
     private final Attendance attendance;
+    private final List<Person> membersToMarkAttendance = new ArrayList<>();
+    private final List<Telegram> unmatchedTelegrams = new ArrayList<>();
+    private final List<Person> membersAttendanceAlreadyMarked = new ArrayList<>();
+    private final List<Person> membersAttendanceMarkSuccess = new ArrayList<>();
 
     /**
      * Constructs a {@code MarkAttendanceCommand} that marks the attendance
@@ -63,15 +70,21 @@ public class MarkAttendanceCommand extends AttendanceMarkingCommand {
     public CommandResult execute(Model model) throws CommandException {
         requireNonNull(model);
         List<Person> lastShownList = model.getFilteredPersonList();
-        List<Person> peopleToMarkAttendance = findByTelegram(telegrams, lastShownList);
-        List<String> peopleNames = peopleToMarkAttendance.stream().map(p -> p.getName().toString()).toList();
-        if (peopleToMarkAttendance.isEmpty()) {
-            throw new CommandException(String.format(Messages.MESSAGE_INVALID_TELEGRAM, telegrams));
+        findByTelegram(telegrams, lastShownList);
+        if (!unmatchedTelegrams.isEmpty()) {
+            throw new CommandException(String.format(Messages.MESSAGE_INVALID_TELEGRAM, unmatchedTelegrams));
         }
 
-        markAttendance(model, peopleToMarkAttendance, this.attendance);
+        markAttendance(model, membersToMarkAttendance, this.attendance);
         model.updateFilteredPersonList(PREDICATE_SHOW_ALL_PERSONS);
-        return new CommandResult(String.format(MESSAGE_MARK_PERSON_SUCCESS, attendance, peopleNames));
+
+        List<String> peopleNames = membersAttendanceMarkSuccess.stream().map(p -> p.getName().toString()).toList();
+        String commandResultMessage = this.membersAttendanceAlreadyMarked.isEmpty()
+                ? String.format(MESSAGE_MARK_MEMBER_SUCCESS, attendance, peopleNames)
+                : String.format(MESSAGE_MARK_MEMBER_SUCCESS, attendance, peopleNames)
+                + '\n' + String.format(MESSAGE_CONTAIN_MARKED_MEMBER, this.membersAttendanceAlreadyMarked.stream()
+                .map(Person::getName).toList());
+        return new CommandResult(commandResultMessage);
     }
 
     @Override
@@ -102,24 +115,39 @@ public class MarkAttendanceCommand extends AttendanceMarkingCommand {
      * Find person with target telegram handle in current contact list
      * @param telegrams Target telegram handle to search in peopleList
      * @param peopleList All people in current contact list view
-     * @return Person with {@code telegram} if it exists, else return person not found
+     *      Add member to {@code membersToMarkAttendance} if their telegram handles is in input list;
+     *      add telegram handles that don't map to a member to {@code unmatchedTelegrams}
+     *      Set {@code membersToMarkAttendance} and {@code unmatchedTelegrams} to object private variables accordingly.
      */
-    protected static List<Person> findByTelegram(List<Telegram> telegrams, List<Person> peopleList) {
-        List<Person> peopleToMark = new ArrayList<>();
+    private void findByTelegram(List<Telegram> telegrams, List<Person> peopleList) {
+        List<Telegram> mappedTelegrams = new ArrayList<>();
         for (Person person: peopleList) {
             if (telegrams.contains(person.getTelegram())) {
-                peopleToMark.add(person);
+                membersToMarkAttendance.add(person);
+                mappedTelegrams.add(person.getTelegram());
             }
         }
-        return peopleToMark;
+
+        for (Telegram t: telegrams) {
+            if (!mappedTelegrams.contains(t)) {
+                unmatchedTelegrams.add(t);
+            }
+        }
     }
 
 
     /**
      * Creates and returns a {@code Person} with updated attendances that includes the {@code attendance} parameter
-     * The attendance list will automatically keep the same if the added attendance already exists.
+     * For members that already have attendance at the specified date, add it to {@code membersAttendanceAlreadyMarked}
      */
-    private Person addAttendanceToPerson(Person person, Attendance attendance) {
+    private Person addAttendanceToPerson(Person person, Attendance attendance) throws CommandException {
+        if (!person.isMember()) {
+            throw new CommandException(MESSAGE_NONMEMBER_ATTENDANCE);
+        }
+        if (person.getAttendance().contains(attendance)) {
+            this.membersAttendanceAlreadyMarked.add(person);
+            return person;
+        }
         Set<Attendance> newAttendanceList = new HashSet<>(person.getAttendance());
         newAttendanceList.add(attendance);
         Name name = person.getName();
@@ -130,10 +158,12 @@ public class MarkAttendanceCommand extends AttendanceMarkingCommand {
         Set<Attendance> updatedAttendances = newAttendanceList;
         FavouriteStatus favouriteStatus = person.getFavouriteStatus();
 
-        return new Person(name, phone, email, telegram, roles, updatedAttendances, favouriteStatus);
+        Person newPerson = new Person(name, phone, email, telegram, roles, updatedAttendances, favouriteStatus);
+        membersAttendanceMarkSuccess.add(newPerson);
+        return newPerson;
     }
 
-    private void markAttendance(Model model, List<Person> peopleToMark, Attendance attendance) {
+    private void markAttendance(Model model, List<Person> peopleToMark, Attendance attendance) throws CommandException {
         for (Person p: peopleToMark) {
             Person markedPerson = addAttendanceToPerson(p, attendance);
             model.setPerson(p, markedPerson);

--- a/src/main/java/seedu/address/logic/commands/UnmarkAttendanceCommand.java
+++ b/src/main/java/seedu/address/logic/commands/UnmarkAttendanceCommand.java
@@ -1,11 +1,12 @@
 package seedu.address.logic.commands;
 
 import static java.util.Objects.requireNonNull;
-import static seedu.address.logic.commands.MarkAttendanceCommand.findByTelegram;
+import static seedu.address.logic.Messages.MESSAGE_NONMEMBER_ATTENDANCE;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_DATE;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_TELEGRAM;
 import static seedu.address.model.Model.PREDICATE_SHOW_ALL_PERSONS;
 
+import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
@@ -38,11 +39,17 @@ public class UnmarkAttendanceCommand extends AttendanceMarkingCommand {
             + "Example: " + COMMAND_WORD + " " + PREFIX_TELEGRAM + "alexYeoh "
             + PREFIX_TELEGRAM + "berniceYu " + PREFIX_DATE + "2024-10-21";
 
-    public static final String MESSAGE_UNMARK_PERSON_SUCCESS =
-            "Successfully unmark the attendance on %1$s for these people: %2$s";
+    public static final String MESSAGE_UNMARK_MEMBER_SUCCESS =
+            "Successfully unmark the attendance on %1$s for member(s): %2$s";
+    public static final String MESSAGE_CONTAIN_UNMARKED_MEMBER =
+            "Please note that attendance of %1$s is already unmarked.";
 
     private final List<Telegram> telegrams;
     private final Attendance attendance;
+    private final List<Telegram> unmatchedTelegrams = new ArrayList<>();
+    private final List<Person> membersToUnmarkAttendance = new ArrayList<>();
+    private final List<Person> membersAttendanceAlreadyUnmarked = new ArrayList<>();
+    private final List<Person> membersAttendanceUnmarkSuccess = new ArrayList<>();
 
     /**
      * Constructs a {@code UnMarkAttendanceCommand} that unmarks (deletes) the attendance
@@ -64,16 +71,21 @@ public class UnmarkAttendanceCommand extends AttendanceMarkingCommand {
     public CommandResult execute(Model model) throws CommandException {
         requireNonNull(model);
         List<Person> lastShownList = model.getFilteredPersonList();
-        List<Person> peopleToUnmarkAttendance = findByTelegram(telegrams, lastShownList);
-        List<String> peopleNames = peopleToUnmarkAttendance.stream().map(p -> p.getName().toString()).toList();
-        if (peopleToUnmarkAttendance.isEmpty()) {
-            throw new CommandException(String.format(Messages.MESSAGE_INVALID_TELEGRAM, telegrams));
+        findByTelegram(telegrams, lastShownList);
+        if (!unmatchedTelegrams.isEmpty()) {
+            throw new CommandException(String.format(Messages.MESSAGE_INVALID_TELEGRAM, unmatchedTelegrams));
         }
 
-        unmarkAttendance(model, peopleToUnmarkAttendance, this.attendance);
+        unmarkAttendance(model, membersToUnmarkAttendance, this.attendance);
         model.updateFilteredPersonList(PREDICATE_SHOW_ALL_PERSONS);
-        return new CommandResult(String.format(
-                MESSAGE_UNMARK_PERSON_SUCCESS, attendance, peopleNames));
+
+        List<String> peopleNames = membersAttendanceUnmarkSuccess.stream().map(p -> p.getName().toString()).toList();
+        String commandResultMessage = this.membersAttendanceAlreadyUnmarked.isEmpty()
+                ? String.format(MESSAGE_UNMARK_MEMBER_SUCCESS, attendance, peopleNames)
+                : String.format(MESSAGE_UNMARK_MEMBER_SUCCESS, attendance, peopleNames)
+                + '\n' + String.format(MESSAGE_CONTAIN_UNMARKED_MEMBER, this.membersAttendanceAlreadyUnmarked.stream()
+                .map(Person::getName).toList());
+        return new CommandResult(commandResultMessage);
     }
 
     @Override
@@ -102,9 +114,17 @@ public class UnmarkAttendanceCommand extends AttendanceMarkingCommand {
 
     /**
      * Creates and returns a {@code Person} with the {@code attendance} parameter removed from its attendance list
-     * The attendance list will automatically keep the same if the attendance doesn't exist initially.
+     * For members that initially don't have an attendance at the specified date,
+     * add it to {@code membersAttendanceAlreadyUnmarked}
      */
-    private Person removeAttendanceToPerson(Person person, Attendance attendance) {
+    private Person removeAttendanceToPerson(Person person, Attendance attendance) throws CommandException {
+        if (!person.isMember()) {
+            throw new CommandException(MESSAGE_NONMEMBER_ATTENDANCE);
+        }
+        if (!person.getAttendance().contains(attendance)) {
+            this.membersAttendanceAlreadyUnmarked.add(person);
+            return person;
+        }
         Set<Attendance> newAttendanceList = new HashSet<>(person.getAttendance());
         newAttendanceList.remove(attendance);
         Name name = person.getName();
@@ -115,13 +135,44 @@ public class UnmarkAttendanceCommand extends AttendanceMarkingCommand {
         Set<Attendance> updatedAttendances = newAttendanceList;
         FavouriteStatus favouriteStatus = person.getFavouriteStatus();
 
-        return new Person(name, phone, email, telegram, roles, updatedAttendances, favouriteStatus);
+        Person newPerson = new Person(name, phone, email, telegram, roles, updatedAttendances, favouriteStatus);
+        membersAttendanceUnmarkSuccess.add(newPerson);
+        return newPerson;
     }
 
-    private void unmarkAttendance(Model model, List<Person> peopleToMark, Attendance attendance) {
-        for (Person p: peopleToMark) {
+    private void unmarkAttendance(
+            Model model, List<Person> peopleToUnmark, Attendance attendance) throws CommandException {
+        for (Person p: peopleToUnmark) {
             Person markedPerson = removeAttendanceToPerson(p, attendance);
             model.setPerson(p, markedPerson);
         }
     }
+
+    /**
+     * Find person with target telegram handle in current contact list
+     * @param telegrams Target telegram handle to search in peopleList
+     * @param peopleList All people in current contact list view
+     *
+     *      Add member to {@code membersToUnmarkAttendance} if their telegram handles is in input list;
+     *      Add telegram handles that don't map to a member to {@code unmatchedTelegrams}
+     *      Set {@code membersToUnmarkAttendance} and {@code unmatchedTelegrams}
+     *                   to object private variables accordingly.
+     */
+    private void findByTelegram(List<Telegram> telegrams, List<Person> peopleList) {
+        List<Telegram> mappedTelegrams = new ArrayList<>();
+        for (Person person: peopleList) {
+            if (telegrams.contains(person.getTelegram())) {
+                membersToUnmarkAttendance.add(person);
+                mappedTelegrams.add(person.getTelegram());
+            }
+        }
+
+
+        for (Telegram t: telegrams) {
+            if (!mappedTelegrams.contains(t)) {
+                unmatchedTelegrams.add(t);
+            }
+        }
+    }
+
 }

--- a/src/main/java/seedu/address/logic/parser/AddressBookParser.java
+++ b/src/main/java/seedu/address/logic/parser/AddressBookParser.java
@@ -59,6 +59,7 @@ public class AddressBookParser {
 
         switch (commandWord) {
 
+
         case AddCommand.COMMAND_WORD:
         case AddCommand.COMMAND_ALIAS:
             return new AddCommandParser().parse(arguments);
@@ -85,7 +86,7 @@ public class AddressBookParser {
 
         case ListAttendanceCommand.COMMAND_WORD:
         case ListAttendanceCommand.COMMAND_ALIAS:
-            return new ListAttendanceCommand();
+            return new ListAttendanceCommandParser().parse(arguments);
 
         case MarkAttendanceCommand.COMMAND_WORD:
         case MarkAttendanceCommand.COMMAND_ALIAS:

--- a/src/main/java/seedu/address/logic/parser/AttendanceMarkingCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/AttendanceMarkingCommandParser.java
@@ -32,7 +32,6 @@ public class AttendanceMarkingCommandParser implements Parser<AttendanceMarkingC
      */
     public AttendanceMarkingCommand parse(String args) throws ParseException {
         ArgumentMultimap argumentMultimap = ArgumentTokenizer.tokenize(args, PREFIX_TELEGRAM, PREFIX_DATE);
-
         if (!arePrefixesPresent(argumentMultimap, PREFIX_TELEGRAM, PREFIX_DATE)
                 || !argumentMultimap.getPreamble().isEmpty()) {
             if (markType.equals(MarkAttendanceCommand.COMMAND_WORD)) {

--- a/src/main/java/seedu/address/logic/parser/ListAttendanceCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/ListAttendanceCommandParser.java
@@ -11,7 +11,8 @@ import seedu.address.logic.parser.exceptions.ParseException;
 public class ListAttendanceCommandParser implements Parser<ListAttendanceCommand> {
     @Override
     public ListAttendanceCommand parse(String userInput) throws ParseException {
-        if (userInput != null) {
+        System.out.println("user input null? " + userInput + "    " + userInput.isEmpty());
+        if (!userInput.isEmpty()) {
             throw new ParseException(String.format(MESSAGE_NO_ADDITIONAL_PARAMS, ListAttendanceCommand.COMMAND_WORD));
         }
         return new ListAttendanceCommand();

--- a/src/main/java/seedu/address/logic/parser/ListAttendanceCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/ListAttendanceCommandParser.java
@@ -1,0 +1,19 @@
+package seedu.address.logic.parser;
+
+import static seedu.address.logic.Messages.MESSAGE_NO_ADDITIONAL_PARAMS;
+
+import seedu.address.logic.commands.ListAttendanceCommand;
+import seedu.address.logic.parser.exceptions.ParseException;
+
+/**
+ * Parse ListAttendanceCommand and check if it contains extra user input.
+ */
+public class ListAttendanceCommandParser implements Parser<ListAttendanceCommand> {
+    @Override
+    public ListAttendanceCommand parse(String userInput) throws ParseException {
+        if (userInput != null) {
+            throw new ParseException(String.format(MESSAGE_NO_ADDITIONAL_PARAMS, ListAttendanceCommand.COMMAND_WORD));
+        }
+        return new ListAttendanceCommand();
+    }
+}

--- a/src/main/java/seedu/address/logic/parser/ParserUtil.java
+++ b/src/main/java/seedu/address/logic/parser/ParserUtil.java
@@ -108,8 +108,11 @@ public class ParserUtil {
     public static Attendance parseAttendance(String dateString) throws ParseException {
         requireNonNull(dateString);
         String trimmedDateString = dateString.trim();
-        if (!Attendance.isValidDate(trimmedDateString)) {
+        if (!Attendance.isValidDateFormat(trimmedDateString)) {
             throw new ParseException(Attendance.MESSAGE_CONSTRAINTS);
+        }
+        if (!Attendance.isValidDateTime(trimmedDateString)) {
+            throw new ParseException(Attendance.MESSAGE_TIME_CONSTRAINTS);
         }
         return new Attendance(trimmedDateString);
     }

--- a/src/main/java/seedu/address/model/attendance/Attendance.java
+++ b/src/main/java/seedu/address/model/attendance/Attendance.java
@@ -8,12 +8,14 @@ import java.time.format.DateTimeParseException;
 
 /**
  * Represents an Attendance session for a contact in the address book.
- * Guarantees: immutable; session is valid as declared in {@link #isValidDate(String)}
+ * Guarantees: immutable; session is valid as declared in {@link #isValidDateFormat(String)}
  */
 public class Attendance {
 
     public static final String MESSAGE_CONSTRAINTS = "Session date should be valid and "
             + "in the form YYYY-MM-DD";
+
+    public static final String MESSAGE_TIME_CONSTRAINTS = "Session date should not be a future date";
 
     public static final String VALIDATION_REGEX =
             "^\\d{4}\\-(0[1-9]|1[012])\\-(0[1-9]|[12][0-9]|3[01])$";
@@ -26,7 +28,7 @@ public class Attendance {
      */
     public Attendance(String date) {
         requireNonNull(date);
-        checkArgument(isValidDate(date), MESSAGE_CONSTRAINTS);
+        checkArgument(isValidDateFormat(date), MESSAGE_CONSTRAINTS);
         session = LocalDate.parse(date);
     }
 
@@ -38,7 +40,7 @@ public class Attendance {
      * @param test A test date string.
      * @return Boolean representing validity of test date string
      */
-    public static boolean isValidDate(String test) {
+    public static boolean isValidDateFormat(String test) {
         try {
             LocalDate.parse(test);
             return test.matches(VALIDATION_REGEX);
@@ -47,6 +49,15 @@ public class Attendance {
         }
     }
 
+    /**
+     * Returns true if a given string is before or same as current date.
+     * @param test A test date string.
+     * @return Boolean representing time validity of test date string
+     */
+    public static boolean isValidDateTime(String test) {
+        LocalDate date = LocalDate.parse(test);
+        return !date.isAfter(LocalDate.now());
+    }
     @Override
     public boolean equals(Object other) {
         if (other == this) {

--- a/src/main/java/seedu/address/storage/JsonAdaptedAttendance.java
+++ b/src/main/java/seedu/address/storage/JsonAdaptedAttendance.java
@@ -41,7 +41,7 @@ public class JsonAdaptedAttendance {
      * @throws IllegalValueException if there were any data constraints violated in the adapted attendance.
      */
     public Attendance toModelType() throws IllegalValueException {
-        if (!Attendance.isValidDate(session)) {
+        if (!Attendance.isValidDateFormat(session)) {
             throw new IllegalValueException(Attendance.MESSAGE_CONSTRAINTS);
         }
         return new Attendance(session);


### PR DESCRIPTION
Fixes #141, fixes #140, fixes #139, fixes #138, fixes #137, fixes #124, fixes #123, fixes #122, fixes #110, fixes #109, fixes #108 

1. Grammar errors for `attendance` and `mark` `unmark` message display:
    Replace "people" to "member(s)"

![image](https://github.com/user-attachments/assets/13d7e412-cb8e-4c11-9d00-7e01b9adf566)

<img width="500" alt="a8923db5587d54aebaa26fa8601a95a" src="https://github.com/user-attachments/assets/601c774f-0e5f-48ac-9529-870708f2ca69">

2. Disallow extra user input to `attendance` command
![image](https://github.com/user-attachments/assets/3952b782-97e1-454e-9720-5bc1749c0500)

3. Inform user when partial telegram handle is invalid for `mark` and `unmark`
When some of the user input telegram handles are valid and some are not, as long there exist one inexist telegram handle, it will output invalid telegram handles and won't mark/unmark any attendance
![image](https://github.com/user-attachments/assets/ec9cf162-f07c-4034-8826-cbb1eac20997)

4. `mark` and `unmark` disallow future dates
<img width="551" alt="9c363ffcb200ff14fa7d84620c29193" src="https://github.com/user-attachments/assets/3a1406e0-7f8b-4f88-a81e-2b9709f9dd0c">

![image](https://github.com/user-attachments/assets/b22178ab-bc6b-4a2e-a4b3-46deaf254683)

5. Handle members with attendance already marked for `mark` and members with attendance already unmarked for `unmark`
Under these situation, the command will normally mark/unmark the rest fo the members, but specifically listed out the unchanged members.
 
<img width="554" alt="d3f40de03ee25ad9fdb5cbddcc34d12" src="https://github.com/user-attachments/assets/ab5adc30-5092-4689-8760-fe83008549f0">

![image](https://github.com/user-attachments/assets/0329b167-9c48-457e-988a-1fd87391a044)

6. Disallow attendance mark/unmark for non-member contacts
Throw an exception if the input telegram handle contains any non-member contact.
<img width="556" alt="8fec0150e1414e341f4fc7a1735af72" src="https://github.com/user-attachments/assets/2c460746-8ca7-42d1-862a-e50d90bf569d">
