### PR TITLE
Fix bugs for `switch` and add `deleteProfile` command

### DIFF
--- a/src/main/java/seedu/address/MainApp.java
+++ b/src/main/java/seedu/address/MainApp.java
@@ -182,5 +182,11 @@ public class MainApp extends Application {
         } catch (IOException e) {
             logger.severe("Failed to save preferences " + StringUtil.getDetails(e));
         }
+
+        try {
+            storage.saveAddressBook(model.getAddressBook());
+        } catch (IOException e) {
+            logger.severe("Failed to save contacts " + StringUtil.getDetails(e));
+        }
     }
 }

--- a/src/main/java/seedu/address/MainApp.java
+++ b/src/main/java/seedu/address/MainApp.java
@@ -21,6 +21,8 @@ import seedu.address.model.ModelManager;
 import seedu.address.model.ReadOnlyAddressBook;
 import seedu.address.model.ReadOnlyUserPrefs;
 import seedu.address.model.UserPrefs;
+import seedu.address.model.profile.exceptions.IllegalProfileNameException;
+import seedu.address.model.profile.exceptions.IllegalProfilePathException;
 import seedu.address.model.util.SampleDataUtil;
 import seedu.address.storage.AddressBookStorage;
 import seedu.address.storage.JsonAddressBookStorage;
@@ -185,8 +187,18 @@ public class MainApp extends Application {
 
         try {
             storage.saveAddressBook(model.getAddressBook());
+        } catch (IllegalProfilePathException | IllegalProfileNameException e) {
+            logger.severe("Contacts could not be saved due to: " + e.getMessage());
+            return;
         } catch (IOException e) {
             logger.severe("Failed to save contacts " + StringUtil.getDetails(e));
         }
+
+        try {
+            storage.deleteOrphanedProfiles(model.getUserPrefs());
+        } catch (IOException e) {
+            logger.severe("Failed to delete contacts " + StringUtil.getDetails(e));
+        }
+
     }
 }

--- a/src/main/java/seedu/address/commons/util/FileUtil.java
+++ b/src/main/java/seedu/address/commons/util/FileUtil.java
@@ -5,6 +5,7 @@ import java.nio.file.Files;
 import java.nio.file.InvalidPathException;
 import java.nio.file.Path;
 import java.nio.file.Paths;
+import java.util.stream.Stream;
 
 /**
  * Writes and reads files
@@ -80,4 +81,12 @@ public class FileUtil {
         Files.write(file, content.getBytes(CHARSET));
     }
 
+    public static Stream<Path> getSiblingsAtPath(Path filePath) throws IOException {
+        Path parentDir = filePath.getParent();
+        return Files.list(parentDir);
+    }
+
+    public static void deleteFileAtPath(Path path) throws IOException {
+        Files.delete(path);
+    }
 }

--- a/src/main/java/seedu/address/logic/LogicManager.java
+++ b/src/main/java/seedu/address/logic/LogicManager.java
@@ -53,7 +53,6 @@ public class LogicManager implements Logic {
 
         try {
             storage.saveAddressBook(model.getAddressBook());
-            storage.saveUserPrefs(model.getUserPrefs());
             syncAddressBook();
         } catch (AccessDeniedException e) {
             throw new CommandException(String.format(FILE_OPS_PERMISSION_ERROR_FORMAT, e.getMessage()), e);

--- a/src/main/java/seedu/address/logic/LogicManager.java
+++ b/src/main/java/seedu/address/logic/LogicManager.java
@@ -18,6 +18,8 @@ import seedu.address.model.AddressBook;
 import seedu.address.model.Model;
 import seedu.address.model.ReadOnlyAddressBook;
 import seedu.address.model.person.Person;
+import seedu.address.model.profile.exceptions.IllegalProfileNameException;
+import seedu.address.model.profile.exceptions.IllegalProfilePathException;
 import seedu.address.storage.Storage;
 
 /**
@@ -60,6 +62,9 @@ public class LogicManager implements Logic {
             throw new CommandException(String.format(FILE_OPS_ERROR_FORMAT, ioe.getMessage()), ioe);
         } catch (DataLoadingException dle) {
             throw new CommandException(String.format(FILE_OPS_LOAD_ERROR, dle.getMessage()));
+        } catch (IllegalProfilePathException | IllegalProfileNameException e) {
+            logger.severe(model.getAddressBook().toString());
+            throw new CommandException(String.format(FILE_OPS_ERROR_FORMAT, "\n" + e.getMessage()));
         }
 
         return commandResult;

--- a/src/main/java/seedu/address/logic/commands/DeleteProfileCommand.java
+++ b/src/main/java/seedu/address/logic/commands/DeleteProfileCommand.java
@@ -45,9 +45,6 @@ public class DeleteProfileCommand extends Command {
         } catch (IllegalProfilePathException | IllegalProfileNameException e) {
             throw new CommandException(MESSAGE_ILLEGAL_MODIFICATION);
         }
-        if (!Profile.isValidProfileName(curProfileName)) {
-            throw new CommandException(MESSAGE_ILLEGAL_MODIFICATION);
-        }
         if (curProfileName.equals(profileName.toString())) {
             throw new CommandException(MESSAGE_IN_USE);
         }

--- a/src/main/java/seedu/address/logic/commands/DeleteProfileCommand.java
+++ b/src/main/java/seedu/address/logic/commands/DeleteProfileCommand.java
@@ -64,11 +64,10 @@ public class DeleteProfileCommand extends Command {
         }
 
         // instanceof handles nulls
-        if (!(other instanceof DeleteProfileCommand)) {
+        if (!(other instanceof DeleteProfileCommand otherDeleteProfile)) {
             return false;
         }
 
-        DeleteProfileCommand otherDeleteProfile = (DeleteProfileCommand) other;
         return profileName.equals(otherDeleteProfile.profileName);
     }
 

--- a/src/main/java/seedu/address/logic/commands/DeleteProfileCommand.java
+++ b/src/main/java/seedu/address/logic/commands/DeleteProfileCommand.java
@@ -1,0 +1,78 @@
+package seedu.address.logic.commands;
+
+import static java.util.Objects.requireNonNull;
+import static seedu.address.model.profile.Profile.extractProfileNameFromPathOrThrow;
+
+import java.util.Set;
+
+import seedu.address.logic.commands.exceptions.CommandException;
+import seedu.address.model.Model;
+import seedu.address.model.profile.Profile;
+import seedu.address.model.profile.exceptions.IllegalProfileNameException;
+import seedu.address.model.profile.exceptions.IllegalProfilePathException;
+
+/**
+ * Deletes a profile from the system if it exists and is not currently in use.
+ */
+public class DeleteProfileCommand extends Command {
+    public static final String COMMAND_WORD = "deleteProfile";
+    public static final String COMMAND_ALIAS = "delp";
+    public static final String MESSAGE_USAGE = COMMAND_WORD
+            + ": Deletes an existing profile based on the provided name.\n"
+            + "Parameters: PROFILE_NAME\n"
+            + "Example: " + COMMAND_WORD + " john-doe";
+    public static final String MESSAGE_SUCCESS = "Successfully deleted the profile '%1$s'";
+    public static final String MESSAGE_NO_SUCH_PROFILE = "Profile not found. Unable to delete a non-existing profile.";
+    public static final String MESSAGE_IN_USE = "Unable to delete the profile currently in use. "
+            + "Please switch to a different profile before attempting deletion.";
+    public static final String MESSAGE_ILLEGAL_MODIFICATION =
+            "deleteProfile command does not support illegal file modifications."
+                    + " Please ensure the existing profile name fits our constraints before using this command.\n"
+                    + Profile.MESSAGE_CONSTRAINTS;
+
+    private final Profile profileName;
+    public DeleteProfileCommand(Profile profileName) {
+        this.profileName = (profileName);
+    }
+
+    @Override
+    public CommandResult execute(Model model) throws CommandException {
+        requireNonNull(model);
+
+        String curProfileName;
+        try {
+            curProfileName = extractProfileNameFromPathOrThrow(model.getAddressBookFilePath());
+        } catch (IllegalProfilePathException | IllegalProfileNameException e) {
+            throw new CommandException(MESSAGE_ILLEGAL_MODIFICATION);
+        }
+        if (!Profile.isValidProfileName(curProfileName)) {
+            throw new CommandException(MESSAGE_ILLEGAL_MODIFICATION);
+        }
+        if (curProfileName.equals(profileName.toString())) {
+            throw new CommandException(MESSAGE_IN_USE);
+        }
+        Set<Profile> profiles = model.getProfiles();
+        if (!profiles.contains(profileName)) {
+            throw new CommandException(MESSAGE_NO_SUCH_PROFILE);
+        }
+
+        model.removeFromProfiles(profileName);
+        return new CommandResult(String.format(MESSAGE_SUCCESS, profileName));
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        if (other == this) {
+            return true;
+        }
+
+        // instanceof handles nulls
+        if (!(other instanceof DeleteProfileCommand)) {
+            return false;
+        }
+
+        DeleteProfileCommand otherDeleteProfile = (DeleteProfileCommand) other;
+        return profileName.equals(otherDeleteProfile.profileName);
+    }
+
+}

--- a/src/main/java/seedu/address/logic/commands/SwitchCommand.java
+++ b/src/main/java/seedu/address/logic/commands/SwitchCommand.java
@@ -1,6 +1,7 @@
 package seedu.address.logic.commands;
 
 import static java.util.Objects.requireNonNull;
+import static seedu.address.logic.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
 import static seedu.address.model.profile.Profile.extractProfileNameFromPathOrThrow;
 
 import java.nio.file.Path;
@@ -51,7 +52,7 @@ public class SwitchCommand extends Command {
         if (profile instanceof Profile.EmptyProfile) {
             Set<Profile> profiles = model.getProfiles();
             if (profiles.isEmpty()) {
-                throw new CommandException(MESSAGE_USAGE);
+                throw new CommandException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, MESSAGE_USAGE));
             }
             List<String> profilesList = profiles.stream()
                     .map(Profile::toPath)

--- a/src/main/java/seedu/address/logic/commands/SwitchCommand.java
+++ b/src/main/java/seedu/address/logic/commands/SwitchCommand.java
@@ -58,13 +58,12 @@ public class SwitchCommand extends Command {
                     .flatMap(Profile::extractNameFromPathOrIgnore)
                     .toList();
             assert profilesList.size() > 0 : "There is no profile to switch to. Message usage should have been thrown";
-            throw new CommandException(
-                    String.format(
-                            MESSAGE_SHOW_PROFILES,
-                            String.join(", ", profilesList),
-                            profilesList.get(0)
-                    )
-            );
+            throw new CommandException(String.format(
+                    MESSAGE_SHOW_PROFILES,
+                    String.join(", ", profilesList),
+                    profilesList.get(0)
+            ));
+
         }
 
         Path filePath = profile.toPath();
@@ -73,9 +72,6 @@ public class SwitchCommand extends Command {
         try {
             curProfileName = extractProfileNameFromPathOrThrow(model.getAddressBookFilePath());
         } catch (IllegalProfilePathException | IllegalProfileNameException e) {
-            throw new CommandException(MESSAGE_ILLEGAL_MODIFICATION);
-        }
-        if (!Profile.isValidProfileName(curProfileName)) {
             throw new CommandException(MESSAGE_ILLEGAL_MODIFICATION);
         }
         if (curProfileName.equals(profile.toString())) {

--- a/src/main/java/seedu/address/logic/commands/SwitchCommand.java
+++ b/src/main/java/seedu/address/logic/commands/SwitchCommand.java
@@ -1,15 +1,17 @@
 package seedu.address.logic.commands;
 
 import static java.util.Objects.requireNonNull;
+import static seedu.address.model.profile.Profile.extractProfileNameFromPathOrThrow;
 
 import java.nio.file.Path;
-import java.nio.file.Paths;
+import java.util.List;
 import java.util.Set;
-import java.util.stream.Collectors;
 
 import seedu.address.logic.commands.exceptions.CommandException;
 import seedu.address.model.Model;
 import seedu.address.model.profile.Profile;
+import seedu.address.model.profile.exceptions.IllegalProfileNameException;
+import seedu.address.model.profile.exceptions.IllegalProfilePathException;
 
 
 /**
@@ -28,45 +30,63 @@ public class SwitchCommand extends Command {
             + "Parameters: PROFILE_NAME\n"
             + "Example: " + COMMAND_WORD + " john-doe";
     public static final String MESSAGE_SUCCESS = "Switched to the profile '%1$s'";
-    public static final String MESSAGE_SHOW_PROFILES = "Other profiles: %1$s";
+    public static final String MESSAGE_SHOW_PROFILES = "Switch to one of the other profiles in this list: [%1$s]\n"
+            + "Example: " + COMMAND_WORD + " %2$s";
     public static final String MESSAGE_NO_SWITCH = "Already on: %1$s";
     public static final String MESSAGE_ILLEGAL_MODIFICATION =
-            "We do not support illegal file modifications. Please ensure the profile name fits our constraints:\n"
+            "switch command does not support illegal file modifications."
+                    + " Please ensure the existing profile name fits our constraints before switching.\n"
                     + Profile.MESSAGE_CONSTRAINTS;
 
-    private final Profile profileName;
-    public SwitchCommand(Profile profileName) {
-        this.profileName = (profileName);
+    private final Profile profile;
+    public SwitchCommand(Profile profile) {
+        this.profile = profile;
     }
 
     @Override
     public CommandResult execute(Model model) throws CommandException {
         requireNonNull(model);
 
-        // display all available commands
-        if (profileName instanceof Profile.EmptyProfile) {
+        // display help usage or all other profiles
+        if (profile instanceof Profile.EmptyProfile) {
             Set<Profile> profiles = model.getProfiles();
             if (profiles.isEmpty()) {
                 throw new CommandException(MESSAGE_USAGE);
             }
-            String profilesList = profiles.stream()
-                    .map(Profile::toString)
-                    .collect(Collectors.joining(", "));
-            return new CommandResult(String.format(MESSAGE_SHOW_PROFILES, profilesList));
+            List<String> profilesList = profiles.stream()
+                    .map(Profile::toPath)
+                    .flatMap(Profile::extractNameFromPathOrIgnore)
+                    .toList();
+            assert profilesList.size() > 0 : "There is no profile to switch to. Message usage should have been thrown";
+            throw new CommandException(
+                    String.format(
+                            MESSAGE_SHOW_PROFILES,
+                            String.join(", ", profilesList),
+                            profilesList.get(0)
+                    )
+            );
         }
 
-        Path filePath = Paths.get("data", profileName + ".json");
+        Path filePath = profile.toPath();
         // updates the model to track the profile switch
-        String curProfileName = getProfileName(model.getAddressBookFilePath());
-        if (!Profile.isValidProfile(curProfileName)) {
+        String curProfileName;
+        try {
+            curProfileName = extractProfileNameFromPathOrThrow(model.getAddressBookFilePath());
+        } catch (IllegalProfilePathException | IllegalProfileNameException e) {
             throw new CommandException(MESSAGE_ILLEGAL_MODIFICATION);
         }
-        if (curProfileName.equals(profileName.toString())) {
-            return new CommandResult(String.format(MESSAGE_NO_SWITCH, profileName));
+        if (!Profile.isValidProfileName(curProfileName)) {
+            throw new CommandException(MESSAGE_ILLEGAL_MODIFICATION);
         }
+        if (curProfileName.equals(profile.toString())) {
+            throw new CommandException(String.format(MESSAGE_NO_SWITCH, profile));
+        }
+
+        //add curProfile to other profiles, then update cur file path.
         model.addToProfiles(new Profile(curProfileName));
         model.setAddressBookFilePath(filePath);
-        return new CommandResult(String.format(MESSAGE_SUCCESS, profileName)).markProfileSwitched();
+
+        return new CommandResult(String.format(MESSAGE_SUCCESS, profile)).markProfileSwitched();
     }
 
     @Override
@@ -81,15 +101,7 @@ public class SwitchCommand extends Command {
         }
 
         SwitchCommand otherSwitchCommand = (SwitchCommand) other;
-        return profileName.equals(otherSwitchCommand.profileName);
+        return profile.equals(otherSwitchCommand.profile);
     }
 
-    private static String getProfileName(Path filePath) {
-        boolean startsWithData = filePath.startsWith("data");
-        boolean singleNameFile = filePath.getNameCount() == 2;
-        boolean endsWithJson = filePath.toString().endsWith(".json");
-        assert startsWithData && singleNameFile && endsWithJson : "This file path is not supported";
-        String fileName = filePath.getFileName().toString();
-        return fileName.substring(0, fileName.length() - 5);
-    }
 }

--- a/src/main/java/seedu/address/logic/commands/SwitchCommand.java
+++ b/src/main/java/seedu/address/logic/commands/SwitchCommand.java
@@ -57,7 +57,7 @@ public class SwitchCommand extends Command {
                     .map(Profile::toPath)
                     .flatMap(Profile::extractNameFromPathOrIgnore)
                     .toList();
-            assert profilesList.size() > 0 : "There is no profile to switch to. Message usage should have been thrown";
+            assert !profilesList.isEmpty() : "There is no profile to switch to. Message usage should have been thrown";
             throw new CommandException(String.format(
                     MESSAGE_SHOW_PROFILES,
                     String.join(", ", profilesList),
@@ -92,11 +92,10 @@ public class SwitchCommand extends Command {
         }
 
         // instanceof handles nulls
-        if (!(other instanceof SwitchCommand)) {
+        if (!(other instanceof SwitchCommand otherSwitchCommand)) {
             return false;
         }
 
-        SwitchCommand otherSwitchCommand = (SwitchCommand) other;
         return profile.equals(otherSwitchCommand.profile);
     }
 

--- a/src/main/java/seedu/address/logic/parser/AddressBookParser.java
+++ b/src/main/java/seedu/address/logic/parser/AddressBookParser.java
@@ -74,7 +74,7 @@ public class AddressBookParser {
 
         case DeleteProfileCommand.COMMAND_WORD:
         case DeleteProfileCommand.COMMAND_ALIAS:
-            return new DeleteProfileParser().parse(arguments);
+            return new DeleteProfileCommandParser().parse(arguments);
 
 
         case EditCommand.COMMAND_WORD:

--- a/src/main/java/seedu/address/logic/parser/AddressBookParser.java
+++ b/src/main/java/seedu/address/logic/parser/AddressBookParser.java
@@ -12,6 +12,7 @@ import seedu.address.logic.commands.AddCommand;
 import seedu.address.logic.commands.ClearCommand;
 import seedu.address.logic.commands.Command;
 import seedu.address.logic.commands.DeleteCommand;
+import seedu.address.logic.commands.DeleteProfileCommand;
 import seedu.address.logic.commands.EditCommand;
 import seedu.address.logic.commands.ExitCommand;
 import seedu.address.logic.commands.FindCommand;
@@ -63,54 +64,59 @@ public class AddressBookParser {
         case AddCommand.COMMAND_ALIAS:
             return new AddCommandParser().parse(arguments);
 
-        case EditCommand.COMMAND_WORD:
-        case EditCommand.COMMAND_ALIAS:
-            return new EditCommandParser().parse(arguments);
+        case ClearCommand.COMMAND_WORD:
+        case ClearCommand.COMMAND_ALIAS:
+            return new ClearCommand();
 
         case DeleteCommand.COMMAND_WORD:
         case DeleteCommand.COMMAND_ALIAS:
             return new DeleteCommandParser().parse(arguments);
 
-        case ClearCommand.COMMAND_WORD:
-        case ClearCommand.COMMAND_ALIAS:
-            return new ClearCommand();
+        case DeleteProfileCommand.COMMAND_WORD:
+        case DeleteProfileCommand.COMMAND_ALIAS:
+            return new DeleteProfileParser().parse(arguments);
+
+
+        case EditCommand.COMMAND_WORD:
+        case EditCommand.COMMAND_ALIAS:
+            return new EditCommandParser().parse(arguments);
+
+        case ExitCommand.COMMAND_WORD:
+            return new ExitCommand();
 
         case FindCommand.COMMAND_WORD:
         case FindCommand.COMMAND_ALIAS:
             return new FindCommandParser().parse(arguments);
 
-        case ListCommand.COMMAND_WORD:
-        case ListCommand.COMMAND_ALIAS:
-            return new ListCommand();
+        case HelpCommand.COMMAND_WORD:
+            return new HelpCommand();
 
         case ListAttendanceCommand.COMMAND_WORD:
         case ListAttendanceCommand.COMMAND_ALIAS:
             return new ListAttendanceCommand();
 
+        case ListCommand.COMMAND_WORD:
+        case ListCommand.COMMAND_ALIAS:
+            return new ListCommand();
+
         case MarkAttendanceCommand.COMMAND_WORD:
         case MarkAttendanceCommand.COMMAND_ALIAS:
             return new AttendanceMarkingCommandParser(MarkAttendanceCommand.COMMAND_WORD).parse(arguments);
 
-        case UnmarkAttendanceCommand.COMMAND_WORD:
-        case UnmarkAttendanceCommand.COMMAND_ALIAS:
-            return new AttendanceMarkingCommandParser(UnmarkAttendanceCommand.COMMAND_WORD).parse(arguments);
-
-        case ExitCommand.COMMAND_WORD:
-            return new ExitCommand();
-
-        case HelpCommand.COMMAND_WORD:
-            return new HelpCommand();
-
-        case ViewCommand.COMMAND_WORD:
-            return new ViewCommandParser().parse(arguments);
+        case SortCommand.COMMAND_WORD:
+        case SortCommand.COMMAND_ALIAS:
+            return new SortCommandParser().parse(arguments);
 
         case SwitchCommand.COMMAND_WORD:
         case SwitchCommand.COMMAND_ALIAS:
             return new SwitchCommandParser().parse(arguments);
 
-        case SortCommand.COMMAND_WORD:
-        case SortCommand.COMMAND_ALIAS:
-            return new SortCommandParser().parse(arguments);
+        case UnmarkAttendanceCommand.COMMAND_WORD:
+        case UnmarkAttendanceCommand.COMMAND_ALIAS:
+            return new AttendanceMarkingCommandParser(UnmarkAttendanceCommand.COMMAND_WORD).parse(arguments);
+
+        case ViewCommand.COMMAND_WORD:
+            return new ViewCommandParser().parse(arguments);
 
         default:
             logger.finer("This user input caused a ParseException: " + userInput);

--- a/src/main/java/seedu/address/logic/parser/DeleteProfileCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/DeleteProfileCommandParser.java
@@ -1,5 +1,7 @@
 package seedu.address.logic.parser;
 
+import static seedu.address.logic.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
+
 import seedu.address.logic.commands.DeleteProfileCommand;
 import seedu.address.logic.parser.exceptions.ParseException;
 import seedu.address.model.profile.Profile;
@@ -15,6 +17,9 @@ public class DeleteProfileCommandParser implements Parser<DeleteProfileCommand> 
      * @throws ParseException if the user input does not conform to the expected format.
      */
     public DeleteProfileCommand parse(String args) throws ParseException {
+        if (args.isEmpty()) {
+            throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, DeleteProfileCommand.MESSAGE_USAGE));
+        }
         Profile profileName = ParserUtil.parseProfileName(args.toLowerCase());
         return new DeleteProfileCommand(profileName);
     }

--- a/src/main/java/seedu/address/logic/parser/DeleteProfileCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/DeleteProfileCommandParser.java
@@ -7,7 +7,7 @@ import seedu.address.model.profile.Profile;
 /**
  * Parses input arguments and creates a new {@code DeleteProfileCommand} object.
  */
-public class DeleteProfileParser implements Parser<DeleteProfileCommand> {
+public class DeleteProfileCommandParser implements Parser<DeleteProfileCommand> {
 
     /**
      * Parses the given {@code String} of arguments in the context of the DeleteProfileCommand

--- a/src/main/java/seedu/address/logic/parser/DeleteProfileParser.java
+++ b/src/main/java/seedu/address/logic/parser/DeleteProfileParser.java
@@ -1,0 +1,21 @@
+package seedu.address.logic.parser;
+
+import seedu.address.logic.commands.DeleteProfileCommand;
+import seedu.address.logic.parser.exceptions.ParseException;
+import seedu.address.model.profile.Profile;
+
+/**
+ * Parses input arguments and creates a new {@code DeleteProfileCommand} object.
+ */
+public class DeleteProfileParser implements Parser<DeleteProfileCommand> {
+
+    /**
+     * Parses the given {@code String} of arguments in the context of the DeleteProfileCommand
+     * and returns a DeleteProfileCommand object for execution.
+     * @throws ParseException if the user input does not conform to the expected format.
+     */
+    public DeleteProfileCommand parse(String args) throws ParseException {
+        Profile profileName = ParserUtil.parseProfileName(args.toLowerCase());
+        return new DeleteProfileCommand(profileName);
+    }
+}

--- a/src/main/java/seedu/address/logic/parser/ParserUtil.java
+++ b/src/main/java/seedu/address/logic/parser/ParserUtil.java
@@ -1,7 +1,6 @@
 package seedu.address.logic.parser;
 
 import static java.util.Objects.requireNonNull;
-import static seedu.address.logic.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
 
 import java.util.Collection;
 import java.util.HashSet;
@@ -152,7 +151,7 @@ public class ParserUtil {
         requireNonNull(profileName);
         String trimmedProfileName = profileName.trim();
         if (!Profile.isValidProfileName(trimmedProfileName)) {
-            throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, Profile.MESSAGE_CONSTRAINTS));
+            throw new ParseException(Profile.MESSAGE_CONSTRAINTS);
         }
         return new Profile(trimmedProfileName);
     }

--- a/src/main/java/seedu/address/logic/parser/ParserUtil.java
+++ b/src/main/java/seedu/address/logic/parser/ParserUtil.java
@@ -1,6 +1,7 @@
 package seedu.address.logic.parser;
 
 import static java.util.Objects.requireNonNull;
+import static seedu.address.logic.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
 
 import java.util.Collection;
 import java.util.HashSet;
@@ -151,7 +152,7 @@ public class ParserUtil {
         requireNonNull(profileName);
         String trimmedProfileName = profileName.trim();
         if (!Profile.isValidProfileName(trimmedProfileName)) {
-            throw new ParseException(Profile.MESSAGE_CONSTRAINTS);
+            throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, Profile.MESSAGE_CONSTRAINTS));
         }
         return new Profile(trimmedProfileName);
     }

--- a/src/main/java/seedu/address/logic/parser/ParserUtil.java
+++ b/src/main/java/seedu/address/logic/parser/ParserUtil.java
@@ -150,7 +150,7 @@ public class ParserUtil {
     public static Profile parseProfileName(String profileName) throws ParseException {
         requireNonNull(profileName);
         String trimmedProfileName = profileName.trim();
-        if (!Profile.isValidProfile(trimmedProfileName)) {
+        if (!Profile.isValidProfileName(trimmedProfileName)) {
             throw new ParseException(Profile.MESSAGE_CONSTRAINTS);
         }
         return new Profile(trimmedProfileName);

--- a/src/main/java/seedu/address/logic/parser/SortCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/SortCommandParser.java
@@ -7,14 +7,14 @@ import seedu.address.logic.commands.SortCommand;
 import seedu.address.logic.parser.exceptions.ParseException;
 
 /**
- * Parses input arguments and creates a SortCommand object
+ * Parses input arguments and creates a SortCommand object.
  */
 public class SortCommandParser implements Parser<SortCommand> {
 
     /**
      * Parses the given {@code String} of arguments in the context of the SortCommand
-     * and returns an SortCommand object for execution.
-     * @throws ParseException if the user input does not conform the expected format
+     * and returns a SortCommand object for execution.
+     * @throws ParseException if the user input does not conform to the expected format.
      */
     public SortCommand parse(String args) throws ParseException {
         if (args.isEmpty()) {

--- a/src/main/java/seedu/address/model/Model.java
+++ b/src/main/java/seedu/address/model/Model.java
@@ -58,6 +58,8 @@ public interface Model {
      */
     void addToProfiles(Profile profileName);
 
+    void removeFromProfiles(Profile profileName);
+
     /**
      * Replaces address book data with the data in {@code addressBook}.
      */

--- a/src/main/java/seedu/address/model/ModelManager.java
+++ b/src/main/java/seedu/address/model/ModelManager.java
@@ -91,6 +91,11 @@ public class ModelManager implements Model {
         userPrefs.addToProfiles(profileName);
     }
 
+    @Override
+    public void removeFromProfiles(Profile profileName) {
+        userPrefs.removeFromProfiles(profileName);
+    }
+
     //=========== AddressBook ================================================================================
 
     @Override

--- a/src/main/java/seedu/address/model/UserPrefs.java
+++ b/src/main/java/seedu/address/model/UserPrefs.java
@@ -46,6 +46,10 @@ public class UserPrefs implements ReadOnlyUserPrefs {
         this.profiles.add(profile);
     }
 
+    public void removeFromProfiles(Profile profile) {
+        this.profiles.remove(profile);
+    }
+
     /**
      * Resets the existing data of this {@code UserPrefs} with {@code newUserPrefs}.
      */

--- a/src/main/java/seedu/address/model/UserPrefs.java
+++ b/src/main/java/seedu/address/model/UserPrefs.java
@@ -35,6 +35,13 @@ public class UserPrefs implements ReadOnlyUserPrefs {
         return profiles;
     }
 
+    public void setProfiles(HashSet<Profile> profiles) {
+        this.profiles.clear();
+        if (profiles != null) {
+            this.profiles.addAll(profiles);
+        }
+    }
+
     public void addToProfiles(Profile profile) {
         this.profiles.add(profile);
     }
@@ -46,6 +53,7 @@ public class UserPrefs implements ReadOnlyUserPrefs {
         requireNonNull(newUserPrefs);
         setGuiSettings(newUserPrefs.getGuiSettings());
         setAddressBookFilePath(newUserPrefs.getAddressBookFilePath());
+        setProfiles(newUserPrefs.getProfiles());
     }
 
     public GuiSettings getGuiSettings() {

--- a/src/main/java/seedu/address/model/profile/Profile.java
+++ b/src/main/java/seedu/address/model/profile/Profile.java
@@ -15,9 +15,8 @@ import seedu.address.model.profile.exceptions.IllegalProfilePathException;
  * Represents a user profile with a name.
  */
 public class Profile {
-    public static final String MESSAGE_CONSTRAINTS =
-            "Profile names may contain only letters (a-z, A-Z), numbers (0-9), hyphens (-), "
-                    + "and underscores (_). The name also must be 30 characters or fewer.";
+    public static final String MESSAGE_CONSTRAINTS = "Profile names must be between 1 and 30 characters and can "
+            + "only include letters (a-z, A-Z), numbers (0-9), hyphens (-), and underscores (_).";
     public static final String VALIDATION_REGEX = "^[a-zA-Z0-9-_]+$";
     private static final String DEFAULT_PROFILE = "addressbook";
     private static final String PROFILE_PARENT_DIR = "data";

--- a/src/main/java/seedu/address/model/profile/Profile.java
+++ b/src/main/java/seedu/address/model/profile/Profile.java
@@ -220,11 +220,10 @@ public class Profile {
         }
 
         // instanceof handles nulls
-        if (!(other instanceof Profile)) {
+        if (!(other instanceof Profile otherProfile)) {
             return false;
         }
 
-        Profile otherProfile = (Profile) other;
         return profileName.equalsIgnoreCase(otherProfile.profileName);
     }
 

--- a/src/main/java/seedu/address/model/profile/Profile.java
+++ b/src/main/java/seedu/address/model/profile/Profile.java
@@ -132,10 +132,22 @@ public class Profile {
             return false;
         }
 
-        String lastSegment = filePath.getFileName().toString();
-        String secondToLastSegment = filePath.getName(nameCount - 2).toString();
-        return PROFILE_PARENT_DIR.equals(secondToLastSegment) && lastSegment.endsWith(PROFILE_EXTENSION);
+        // Subdirectories for 'data' is not allowed
+        long dataDirectoryCount = 0;
+        for (int i = 0; i < nameCount; i++) {
+            if (PROFILE_PARENT_DIR.equals(filePath.getName(i).toString())) {
+                dataDirectoryCount++;
+            }
+        }
+        if (dataDirectoryCount > 1) {
+            return false;
+        }
+
+        String fileName = filePath.getFileName().toString();
+        String parentDir = filePath.getName(nameCount - 2).toString();
+        return PROFILE_PARENT_DIR.equals(parentDir) && fileName.endsWith(PROFILE_EXTENSION);
     }
+
 
     /**
      * Helper method to extract the profile name from a file path by removing the

--- a/src/main/java/seedu/address/model/profile/Profile.java
+++ b/src/main/java/seedu/address/model/profile/Profile.java
@@ -4,71 +4,160 @@ import static java.util.Objects.requireNonNull;
 import static seedu.address.commons.util.AppUtil.checkArgument;
 
 import java.nio.file.Path;
+import java.nio.file.Paths;
 import java.util.regex.Pattern;
+import java.util.stream.Stream;
+
+import seedu.address.model.profile.exceptions.IllegalProfileNameException;
+import seedu.address.model.profile.exceptions.IllegalProfilePathException;
 
 /**
  * Represents a user profile with a name.
  */
 public class Profile {
     public static final String MESSAGE_CONSTRAINTS =
-            "The profile name can only contain letters (a-z, A-Z), numbers (0-9), and hyphens (-). "
-                    + "It must also be 30 characters or less.";
-    public static final String VALIDATION_REGEX = "^[a-zA-Z0-9-]+$";
+            "Profile names may contain only letters (a-z, A-Z), numbers (0-9), hyphens (-), "
+                    + "and underscores (_). The name also must be 30 characters or fewer.";
+    public static final String VALIDATION_REGEX = "^[a-zA-Z0-9-_]+$";
     private static final String DEFAULT_PROFILE = "addressbook";
-    public final String profileName;
+    private static final String PROFILE_PARENT_DIR = "data";
+    private static final String PROFILE_EXTENSION = ".json";
+    private final String profileName;
 
+    /**
+     * Constructs a Profile instance with the default profile name.
+     */
     public Profile() {
         this.profileName = DEFAULT_PROFILE;
     }
 
     /**
-     * Constructs a {@code Profile}.
+     * Constructs a Profile with the specified name after validation.
      *
      * @param profileName A valid profile name.
+     * @throws IllegalArgumentException if profile name is invalid.
      */
     public Profile(String profileName) {
         requireNonNull(profileName);
-        checkArgument(isValidProfile(profileName), MESSAGE_CONSTRAINTS);
+        checkArgument(isValidProfileName(profileName), MESSAGE_CONSTRAINTS);
         this.profileName = profileName;
     }
 
     /**
      * Checks if the given profile name is valid based on the following criteria:
      * <ul>
-     *     <li>The profile name must be alphanumeric (a-z, A-Z, 0-9) or contain hyphens (-).</li>
+     *     <li>The profile name must be alphanumeric (a-z, A-Z, 0-9)
+     *     and may include hyphens (-) or underscores (_).</li>
      *     <li>The profile name must not exceed 30 characters in length.</li>
      * </ul>
      *
-     * @param profileName the name of the new profile to validate
+     * @param profileName the name of the new profile to validate.
      * @return true if the profile name is valid according to the criteria, false otherwise
      */
-    public static boolean isValidProfile(String profileName) {
+    public static boolean isValidProfileName(String profileName) {
         Pattern pattern = Pattern.compile(VALIDATION_REGEX);
         return profileName.length() <= 30 && pattern.matcher(profileName).matches();
     }
 
-
     /**
-     * Extracts the profile name from a specified file path.
+     * Checks if the provided file path follows the required format: it must start with "data",
+     * contain exactly one additional path segment representing the profile name, and end with ".json".
      * <p>
-     * This method assumes that the provided {@code filePath} adheres to a specific structure:
-     * it must start with the directory "data", contain exactly two path segments (e.g., "data/profile.json"),
-     * and end with a ".json" file extension. If any of these conditions are not met, an assertion error is thrown.
-     * </p>
-     * <p>
-     * The profile name is derived from the file name by removing the ".json" extension.
+     * Example of a valid path: {@code data/addressbook.json}
+     * Example of an invalid path: {@code data/dir/addressbook.json}
      * </p>
      *
-     * @param filePath the path of the profile file, expected to match "data/{profileName}.json" format
-     * @return the extracted profile name without the ".json" extension.
+     * @param filePath The path to validate.
+     * @return true if the path follows the required format, false otherwise.
      */
-    public static String getProfileName(Path filePath) {
-        boolean startsWithData = filePath.startsWith("data");
-        boolean singleNameFile = filePath.getNameCount() == 2;
-        boolean endsWithJson = filePath.toString().endsWith(".json");
-        assert startsWithData && singleNameFile && endsWithJson : "This file path is not supported";
+    public static boolean isSimpleProfileFilePath(Path filePath) {
+        // Check if the path ends with "data/addressBook.json" structure
+        int nameCount = filePath.getNameCount();
+        boolean endsWithJson = filePath.toString().endsWith(PROFILE_EXTENSION);
+
+        // Check if the last two segments match "data/{profileName}.json"
+        boolean matchesDataStructure =
+                nameCount >= 2
+                        && "data".equals(filePath.getName(nameCount - 2).toString())
+                        && endsWithJson;
+
+        // Check if the profile name follows constraints if matchesDataStructure is true
+        if (matchesDataStructure) {
+            String profileName = filePath.getName(nameCount - 1).toString();
+            profileName = profileName.substring(0, profileName.length() - PROFILE_EXTENSION.length());
+            return isValidProfileName(profileName);
+        }
+        return false;
+    }
+
+    /**
+     * Extracts a profile name from the given file path as a single-element stream if valid;
+     * returns an empty stream if the path or name is invalid.
+     * <p>
+     * Intended for use in stream pipelines where invalid paths can be safely ignored.
+     * </p>
+     *
+     * @param filePath The file path to extract the profile name from.
+     * @return A stream containing the profile name if valid, or an empty stream if invalid.
+     */
+    public static Stream<String> extractNameFromPathOrIgnore(Path filePath) {
+        try {
+            return Stream.of(extractProfileNameFromPathOrThrow(filePath));
+        } catch (IllegalProfilePathException | IllegalProfileNameException e) {
+            return Stream.empty();
+        }
+    }
+
+    /**
+     * Extracts a profile name from the specified path, throwing exceptions if
+     * the path format or name validity requirements are violated.
+     *
+     * @param filePath The path from which to extract the profile name.
+     * @return The extracted profile name.
+     * @throws IllegalProfilePathException if the path format is invalid.
+     * @throws IllegalProfileNameException if the profile name is invalid.
+     */
+    public static String extractProfileNameFromPathOrThrow(Path filePath) {
+        if (!isSimpleProfileFilePath(filePath)) {
+            throw new IllegalProfilePathException();
+        }
+        String profileName = extractProfileName(filePath);
+        if (!isValidProfileName(profileName)) {
+            throw new IllegalProfileNameException();
+        }
+        return profileName;
+    }
+
+    /**
+     * Helper method to extract the profile name from a file path by removing the
+     * ".json" extension. Assumes the path format is valid.
+     *
+     * @param filePath The path from which to extract the profile name.
+     * @return The profile name without the extension.
+     */
+    private static String extractProfileName(Path filePath) {
         String fileName = filePath.getFileName().toString();
-        return fileName.substring(0, fileName.length() - 5);
+        assert isSimpleProfileFilePath(filePath) : "Attempted to extract profile name from an unsupported file path";
+        return fileName.substring(0, fileName.length() - PROFILE_EXTENSION.length());
+    }
+
+    /**
+     * Returns the file path for this profile, formatted as "data/{profileName}.json".
+     *
+     * @return The file path of the profile.
+     */
+    public Path toPath() {
+        return profileStringToPath(profileName);
+    }
+
+    /**
+     * Converts a profile name into a file path in the format "data/{profileName}.json".
+     *
+     * @param profileName The name to convert to a file path.
+     * @return The corresponding profile path.
+     */
+    public static Path profileStringToPath(String profileName) {
+        return Paths.get(PROFILE_PARENT_DIR, profileName + PROFILE_EXTENSION);
     }
 
     /**

--- a/src/main/java/seedu/address/model/profile/Profile.java
+++ b/src/main/java/seedu/address/model/profile/Profile.java
@@ -3,6 +3,7 @@ package seedu.address.model.profile;
 import static java.util.Objects.requireNonNull;
 import static seedu.address.commons.util.AppUtil.checkArgument;
 
+import java.nio.file.Path;
 import java.util.regex.Pattern;
 
 /**
@@ -13,7 +14,12 @@ public class Profile {
             "The profile name can only contain letters (a-z, A-Z), numbers (0-9), and hyphens (-). "
                     + "It must also be 30 characters or less.";
     public static final String VALIDATION_REGEX = "^[a-zA-Z0-9-]+$";
+    private static final String DEFAULT_PROFILE = "addressbook";
     public final String profileName;
+
+    public Profile() {
+        this.profileName = DEFAULT_PROFILE;
+    }
 
     /**
      * Constructs a {@code Profile}.
@@ -39,6 +45,30 @@ public class Profile {
     public static boolean isValidProfile(String profileName) {
         Pattern pattern = Pattern.compile(VALIDATION_REGEX);
         return profileName.length() <= 30 && pattern.matcher(profileName).matches();
+    }
+
+
+    /**
+     * Extracts the profile name from a specified file path.
+     * <p>
+     * This method assumes that the provided {@code filePath} adheres to a specific structure:
+     * it must start with the directory "data", contain exactly two path segments (e.g., "data/profile.json"),
+     * and end with a ".json" file extension. If any of these conditions are not met, an assertion error is thrown.
+     * </p>
+     * <p>
+     * The profile name is derived from the file name by removing the ".json" extension.
+     * </p>
+     *
+     * @param filePath the path of the profile file, expected to match "data/{profileName}.json" format
+     * @return the extracted profile name without the ".json" extension.
+     */
+    public static String getProfileName(Path filePath) {
+        boolean startsWithData = filePath.startsWith("data");
+        boolean singleNameFile = filePath.getNameCount() == 2;
+        boolean endsWithJson = filePath.toString().endsWith(".json");
+        assert startsWithData && singleNameFile && endsWithJson : "This file path is not supported";
+        String fileName = filePath.getFileName().toString();
+        return fileName.substring(0, fileName.length() - 5);
     }
 
     /**

--- a/src/main/java/seedu/address/model/profile/exceptions/IllegalProfileNameException.java
+++ b/src/main/java/seedu/address/model/profile/exceptions/IllegalProfileNameException.java
@@ -1,0 +1,12 @@
+package seedu.address.model.profile.exceptions;
+
+import seedu.address.model.profile.Profile;
+
+/**
+ * Exception thrown when a profile name violates the constraints defined in {@link Profile}.
+ */
+public class IllegalProfileNameException extends RuntimeException {
+    public IllegalProfileNameException() {
+        super("Invalid profile name. Please ensure the profile name fits our constraints");
+    }
+}

--- a/src/main/java/seedu/address/model/profile/exceptions/IllegalProfileNameException.java
+++ b/src/main/java/seedu/address/model/profile/exceptions/IllegalProfileNameException.java
@@ -6,7 +6,8 @@ import seedu.address.model.profile.Profile;
  * Exception thrown when a profile name violates the constraints defined in {@link Profile}.
  */
 public class IllegalProfileNameException extends RuntimeException {
+    public static final String ERR_MSG = "Invalid profile name. Please ensure the profile name fits our constraints";
     public IllegalProfileNameException() {
-        super("Invalid profile name. Please ensure the profile name fits our constraints");
+        super(ERR_MSG);
     }
 }

--- a/src/main/java/seedu/address/model/profile/exceptions/IllegalProfilePathException.java
+++ b/src/main/java/seedu/address/model/profile/exceptions/IllegalProfilePathException.java
@@ -6,7 +6,11 @@ import seedu.address.model.profile.Profile;
  * Exception thrown when a profile path violates the constraints defined in {@link Profile}.
  */
 public class IllegalProfilePathException extends RuntimeException {
+    public static final String ERR_MSG =
+            "Invalid file path. The file must be a .json file located directly under a 'data' directory within the "
+                    + "project root, following the pattern: data/{profileName}.json.";
+
     public IllegalProfilePathException() {
-        super("Invalid file path. Only files following the pattern data/{profileName}.json are supported.");
+        super(ERR_MSG);
     }
 }

--- a/src/main/java/seedu/address/model/profile/exceptions/IllegalProfilePathException.java
+++ b/src/main/java/seedu/address/model/profile/exceptions/IllegalProfilePathException.java
@@ -1,0 +1,12 @@
+package seedu.address.model.profile.exceptions;
+
+import seedu.address.model.profile.Profile;
+
+/**
+ * Exception thrown when a profile path violates the constraints defined in {@link Profile}.
+ */
+public class IllegalProfilePathException extends RuntimeException {
+    public IllegalProfilePathException() {
+        super("Invalid file path. Only files following the pattern data/{profileName}.json are supported.");
+    }
+}

--- a/src/main/java/seedu/address/storage/AddressBookStorage.java
+++ b/src/main/java/seedu/address/storage/AddressBookStorage.java
@@ -6,6 +6,7 @@ import java.util.Optional;
 
 import seedu.address.commons.exceptions.DataLoadingException;
 import seedu.address.model.ReadOnlyAddressBook;
+import seedu.address.model.profile.exceptions.IllegalProfileNameException;
 
 /**
  * Represents a storage for {@link seedu.address.model.AddressBook}.
@@ -41,11 +42,13 @@ public interface AddressBookStorage {
      * @param addressBook cannot be null.
      * @throws IOException if there was any problem writing to the file.
      */
-    void saveAddressBook(ReadOnlyAddressBook addressBook) throws IOException;
+    void saveAddressBook(ReadOnlyAddressBook addressBook) throws IOException, IllegalProfileNameException;
 
     /**
      * @see #saveAddressBook(ReadOnlyAddressBook)
      */
-    void saveAddressBook(ReadOnlyAddressBook addressBook, Path filePath) throws IOException;
-
+    void saveAddressBook(
+        ReadOnlyAddressBook addressBook,
+        Path filePath
+    ) throws IOException, IllegalProfileNameException;
 }

--- a/src/main/java/seedu/address/storage/JsonAddressBookStorage.java
+++ b/src/main/java/seedu/address/storage/JsonAddressBookStorage.java
@@ -1,6 +1,7 @@
 package seedu.address.storage;
 
 import static java.util.Objects.requireNonNull;
+import static seedu.address.model.profile.Profile.extractProfileNameFromPathOrThrow;
 
 import java.io.IOException;
 import java.nio.file.Path;
@@ -13,6 +14,7 @@ import seedu.address.commons.exceptions.IllegalValueException;
 import seedu.address.commons.util.FileUtil;
 import seedu.address.commons.util.JsonUtil;
 import seedu.address.model.ReadOnlyAddressBook;
+import seedu.address.model.profile.exceptions.IllegalProfileNameException;
 
 /**
  * A class to access AddressBook data stored as a json file on the hard disk.
@@ -64,7 +66,7 @@ public class JsonAddressBookStorage implements AddressBookStorage {
     }
 
     @Override
-    public void saveAddressBook(ReadOnlyAddressBook addressBook) throws IOException {
+    public void saveAddressBook(ReadOnlyAddressBook addressBook) throws IOException, IllegalProfileNameException {
         saveAddressBook(addressBook, filePath);
     }
 
@@ -73,10 +75,14 @@ public class JsonAddressBookStorage implements AddressBookStorage {
      *
      * @param filePath location of the data. Cannot be null.
      */
-    public void saveAddressBook(ReadOnlyAddressBook addressBook, Path filePath) throws IOException {
+    public void saveAddressBook(
+            ReadOnlyAddressBook addressBook,
+            Path filePath
+    ) throws IOException, IllegalProfileNameException {
         requireNonNull(addressBook);
         requireNonNull(filePath);
 
+        extractProfileNameFromPathOrThrow(filePath);
         FileUtil.createIfMissing(filePath);
         JsonUtil.saveJsonFile(new JsonSerializableAddressBook(addressBook), filePath);
     }

--- a/src/main/java/seedu/address/storage/Storage.java
+++ b/src/main/java/seedu/address/storage/Storage.java
@@ -14,6 +14,8 @@ import seedu.address.model.UserPrefs;
  */
 public interface Storage extends AddressBookStorage, UserPrefsStorage {
 
+    void deleteOrphanedProfiles(ReadOnlyUserPrefs userPrefs) throws IOException;
+
     @Override
     Optional<UserPrefs> readUserPrefs() throws DataLoadingException;
 

--- a/src/main/java/seedu/address/storage/StorageManager.java
+++ b/src/main/java/seedu/address/storage/StorageManager.java
@@ -1,8 +1,7 @@
 package seedu.address.storage;
 
 import static seedu.address.model.profile.Profile.extractProfileNameFromPathOrThrow;
-import static seedu.address.model.profile.Profile.isSimpleProfileFilePath;
-import static seedu.address.model.profile.Profile.isValidProfileName;
+import static seedu.address.model.profile.Profile.isValidProfileFromPath;
 
 import java.io.IOException;
 import java.nio.file.Path;
@@ -39,8 +38,7 @@ public class StorageManager implements Storage {
     @Override
     public void deleteOrphanedProfiles(ReadOnlyUserPrefs userPrefs) throws IOException {
         Path currentProfilePath = userPrefs.getAddressBookFilePath();
-        assert isSimpleProfileFilePath(currentProfilePath)
-                && isValidProfileName(currentProfilePath.toString())
+        assert isValidProfileFromPath(currentProfilePath)
                 : "Profile deletion should not happen when the current profile path is invalid";
         String curProfileName = extractProfileNameFromPathOrThrow(currentProfilePath);
 

--- a/src/main/java/seedu/address/storage/StorageManager.java
+++ b/src/main/java/seedu/address/storage/StorageManager.java
@@ -24,8 +24,8 @@ import seedu.address.model.profile.Profile;
 public class StorageManager implements Storage {
 
     private static final Logger logger = LogsCenter.getLogger(StorageManager.class);
-    private AddressBookStorage addressBookStorage;
-    private UserPrefsStorage userPrefsStorage;
+    private final AddressBookStorage addressBookStorage;
+    private final UserPrefsStorage userPrefsStorage;
 
     /**
      * Creates a {@code StorageManager} with the given {@code AddressBookStorage} and {@code UserPrefStorage}.

--- a/src/main/java/seedu/address/ui/HelpWindow.java
+++ b/src/main/java/seedu/address/ui/HelpWindow.java
@@ -12,6 +12,7 @@ import seedu.address.commons.core.LogsCenter;
 import seedu.address.logic.commands.AddCommand;
 import seedu.address.logic.commands.ClearCommand;
 import seedu.address.logic.commands.DeleteCommand;
+import seedu.address.logic.commands.DeleteProfileCommand;
 import seedu.address.logic.commands.EditCommand;
 import seedu.address.logic.commands.ExitCommand;
 import seedu.address.logic.commands.FindCommand;
@@ -37,6 +38,7 @@ public class HelpWindow extends UiPart<Stage> {
         AddCommand.MESSAGE_USAGE,
         ClearCommand.MESSAGE_USAGE,
         DeleteCommand.MESSAGE_USAGE,
+        DeleteProfileCommand.MESSAGE_USAGE,
         EditCommand.MESSAGE_USAGE,
         ExitCommand.MESSAGE_USAGE,
         FindCommand.MESSAGE_USAGE,

--- a/src/test/java/seedu/address/logic/LogicManagerTest.java
+++ b/src/test/java/seedu/address/logic/LogicManagerTest.java
@@ -12,6 +12,7 @@ import static seedu.address.testutil.TypicalPersons.AMY;
 
 import java.io.IOException;
 import java.nio.file.AccessDeniedException;
+import java.nio.file.Files;
 import java.nio.file.Path;
 
 import org.junit.jupiter.api.BeforeEach;
@@ -44,9 +45,11 @@ public class LogicManagerTest {
     private Logic logic;
 
     @BeforeEach
-    public void setUp() {
+    public void setUp() throws IOException {
+        Path dataDirectory = temporaryFolder.resolve("data");
+        Files.createDirectories(dataDirectory);
         JsonAddressBookStorage addressBookStorage =
-                new JsonAddressBookStorage(temporaryFolder.resolve("addressBook.json"));
+                new JsonAddressBookStorage(dataDirectory.resolve("addressBook.json"));
         JsonUserPrefsStorage userPrefsStorage = new JsonUserPrefsStorage(temporaryFolder.resolve("userPrefs.json"));
         StorageManager storage = new StorageManager(addressBookStorage, userPrefsStorage);
         logic = new LogicManager(model, storage);
@@ -65,6 +68,7 @@ public class LogicManagerTest {
     }
 
     @Test
+
     public void execute_validCommand_success() throws Exception {
         String listCommand = ListCommand.COMMAND_WORD;
         assertCommandSuccess(listCommand, ListCommand.MESSAGE_SUCCESS, model);

--- a/src/test/java/seedu/address/logic/commands/AddCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/AddCommandTest.java
@@ -127,6 +127,11 @@ public class AddCommandTest {
         }
 
         @Override
+        public void removeFromProfiles(Profile profileName) {
+            throw new AssertionError("This method should not be called.");
+        }
+
+        @Override
         public void addToProfiles(Profile profileName) {
             throw new AssertionError("This method should not be called.");
         }

--- a/src/test/java/seedu/address/logic/commands/DeleteProfileCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/DeleteProfileCommandTest.java
@@ -2,6 +2,7 @@
 package seedu.address.logic.commands;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static seedu.address.testutil.Assert.assertThrows;
 
@@ -27,7 +28,7 @@ public class DeleteProfileCommandTest {
                 String.format(DeleteProfileCommand.MESSAGE_SUCCESS, "deletable-profile"),
                 result.getFeedbackToUser()
         );
-        assertEquals(false, model.getProfiles().contains(profileToDelete));
+        assertFalse(model.getProfiles().contains(profileToDelete));
     }
 
     @Test
@@ -39,7 +40,7 @@ public class DeleteProfileCommandTest {
         DeleteProfileCommand minDeleteCommand = new DeleteProfileCommand(minLengthProfile);
         CommandResult minResult = minDeleteCommand.execute(model);
         assertEquals(String.format(DeleteProfileCommand.MESSAGE_SUCCESS, "a"), minResult.getFeedbackToUser());
-        assertEquals(false, model.getProfiles().contains(minLengthProfile));
+        assertFalse(model.getProfiles().contains(minLengthProfile));
 
         Profile maxLengthProfile = new Profile("a".repeat(30));
         model.addToProfiles(maxLengthProfile);
@@ -50,7 +51,7 @@ public class DeleteProfileCommandTest {
                 String.format(DeleteProfileCommand.MESSAGE_SUCCESS, "a".repeat(30)),
                 maxResult.getFeedbackToUser()
         );
-        assertEquals(false, model.getProfiles().contains(maxLengthProfile));
+        assertFalse(model.getProfiles().contains(maxLengthProfile));
     }
 
     @Test

--- a/src/test/java/seedu/address/logic/commands/DeleteProfileCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/DeleteProfileCommandTest.java
@@ -1,0 +1,104 @@
+
+package seedu.address.logic.commands;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static seedu.address.testutil.Assert.assertThrows;
+
+import org.junit.jupiter.api.Test;
+
+import seedu.address.logic.commands.exceptions.CommandException;
+import seedu.address.model.Model;
+import seedu.address.model.ModelManager;
+import seedu.address.model.profile.Profile;
+
+public class DeleteProfileCommandTest {
+
+    @Test
+    public void execute_deleteExistingProfile_success() throws CommandException {
+        Profile profileToDelete = new Profile("deletable-profile");
+        Model model = new ModelManager();
+        model.addToProfiles(profileToDelete);
+
+        DeleteProfileCommand deleteCommand = new DeleteProfileCommand(profileToDelete);
+        CommandResult result = deleteCommand.execute(model);
+
+        assertEquals(
+                String.format(DeleteProfileCommand.MESSAGE_SUCCESS, "deletable-profile"),
+                result.getFeedbackToUser()
+        );
+        assertEquals(false, model.getProfiles().contains(profileToDelete));
+    }
+
+    @Test
+    public void execute_boundaryProfileNames_success() throws CommandException {
+        Profile minLengthProfile = new Profile("a");
+        Model model = new ModelManager();
+        model.addToProfiles(minLengthProfile);
+
+        DeleteProfileCommand minDeleteCommand = new DeleteProfileCommand(minLengthProfile);
+        CommandResult minResult = minDeleteCommand.execute(model);
+        assertEquals(String.format(DeleteProfileCommand.MESSAGE_SUCCESS, "a"), minResult.getFeedbackToUser());
+        assertEquals(false, model.getProfiles().contains(minLengthProfile));
+
+        Profile maxLengthProfile = new Profile("a".repeat(30));
+        model.addToProfiles(maxLengthProfile);
+
+        DeleteProfileCommand maxDeleteCommand = new DeleteProfileCommand(maxLengthProfile);
+        CommandResult maxResult = maxDeleteCommand.execute(model);
+        assertEquals(
+                String.format(DeleteProfileCommand.MESSAGE_SUCCESS, "a".repeat(30)),
+                maxResult.getFeedbackToUser()
+        );
+        assertEquals(false, model.getProfiles().contains(maxLengthProfile));
+    }
+
+    @Test
+    public void execute_deleteNonExistentProfile_errorMessage() {
+        Profile nonExistentProfile = new Profile("non-existent-profile");
+        Model model = new ModelManager();
+
+        DeleteProfileCommand deleteCommand = new DeleteProfileCommand(nonExistentProfile);
+
+        assertThrows(CommandException.class,
+                DeleteProfileCommand.MESSAGE_NO_SUCH_PROFILE, () -> deleteCommand.execute(model));
+    }
+
+    @Test
+    public void execute_deleteCurrentProfile_errorMessage() {
+        Profile currentProfile = new Profile("active-profile");
+        Model model = new ModelManager();
+        model.addToProfiles(currentProfile);
+        model.setAddressBookFilePath(currentProfile.toPath());
+
+        DeleteProfileCommand deleteCommand = new DeleteProfileCommand(currentProfile);
+
+        assertThrows(CommandException.class,
+                String.format(DeleteProfileCommand.MESSAGE_IN_USE), () -> deleteCommand.execute(model));
+    }
+
+    @Test
+    public void execute_invalidProfileName_exceptionThrown() {
+        Profile validProfile = new Profile("valid-profile");
+        String illegalProfileName = " space-in-name";
+        Model model = new ModelManager();
+        model.setAddressBookFilePath(Profile.profileStringToPath(illegalProfileName));
+
+        DeleteProfileCommand deleteCommand = new DeleteProfileCommand(validProfile);
+
+        assertThrows(CommandException.class,
+                DeleteProfileCommand.MESSAGE_ILLEGAL_MODIFICATION, () -> deleteCommand.execute(model));
+    }
+
+    @Test
+    public void execute_invalidProfileNameWithSubDir_exceptionThrown() {
+        Profile validProfile = new Profile("valid-profile");
+        String illegalProfilePath = "data/name";
+        Model model = new ModelManager();
+        model.setAddressBookFilePath(Profile.profileStringToPath(illegalProfilePath));
+
+        DeleteProfileCommand deleteCommand = new DeleteProfileCommand(validProfile);
+
+        assertThrows(CommandException.class,
+                DeleteProfileCommand.MESSAGE_ILLEGAL_MODIFICATION, () -> deleteCommand.execute(model));
+    }
+}

--- a/src/test/java/seedu/address/logic/commands/DeleteProfileCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/DeleteProfileCommandTest.java
@@ -2,6 +2,9 @@
 package seedu.address.logic.commands;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static seedu.address.testutil.Assert.assertThrows;
 
 import org.junit.jupiter.api.Test;
@@ -100,5 +103,20 @@ public class DeleteProfileCommandTest {
 
         assertThrows(CommandException.class,
                 DeleteProfileCommand.MESSAGE_ILLEGAL_MODIFICATION, () -> deleteCommand.execute(model));
+    }
+
+    @Test
+    public void equals() {
+        Profile profile1 = new Profile("profile1");
+        Profile profile2 = new Profile("profile2");
+        DeleteProfileCommand deleteCommand1 = new DeleteProfileCommand(profile1);
+        DeleteProfileCommand deleteCommand2 = new DeleteProfileCommand(profile1);
+        DeleteProfileCommand deleteCommand3 = new DeleteProfileCommand(profile2);
+
+        assertEquals(deleteCommand1, deleteCommand2);
+        assertEquals(deleteCommand1, deleteCommand1);
+        assertNotEquals(deleteCommand1, deleteCommand3);
+        assertNotEquals("not a DeleteProfileCommand", deleteCommand1);
+        assertNotEquals(null, deleteCommand1);
     }
 }

--- a/src/test/java/seedu/address/logic/commands/DeleteProfileCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/DeleteProfileCommandTest.java
@@ -2,9 +2,7 @@
 package seedu.address.logic.commands;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
-import static org.junit.jupiter.api.Assertions.assertTrue;
 import static seedu.address.testutil.Assert.assertThrows;
 
 import org.junit.jupiter.api.Test;

--- a/src/test/java/seedu/address/logic/commands/SwitchCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/SwitchCommandTest.java
@@ -2,6 +2,7 @@ package seedu.address.logic.commands;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static seedu.address.logic.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
 import static seedu.address.testutil.Assert.assertThrows;
 
 import org.junit.jupiter.api.Test;
@@ -65,7 +66,8 @@ public class SwitchCommandTest {
         SwitchCommand switchCommand = new SwitchCommand(Profile.getEmptyProfile());
 
         assertThrows(CommandException.class,
-                SwitchCommand.MESSAGE_USAGE, () -> switchCommand.execute(model)
+                String.format(MESSAGE_INVALID_COMMAND_FORMAT, SwitchCommand.MESSAGE_USAGE), () ->
+                        switchCommand.execute(model)
         );
     }
 

--- a/src/test/java/seedu/address/logic/commands/SwitchCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/SwitchCommandTest.java
@@ -1,9 +1,7 @@
 package seedu.address.logic.commands;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
-import static org.junit.jupiter.api.Assertions.assertTrue;
 import static seedu.address.testutil.Assert.assertThrows;
 
 import org.junit.jupiter.api.Test;

--- a/src/test/java/seedu/address/logic/commands/SwitchCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/SwitchCommandTest.java
@@ -1,6 +1,9 @@
 package seedu.address.logic.commands;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static seedu.address.testutil.Assert.assertThrows;
 
 import org.junit.jupiter.api.Test;
@@ -110,5 +113,19 @@ public class SwitchCommandTest {
         );
     }
 
+    @Test
+    public void equals() {
+        Profile profile1 = new Profile("profile1");
+        Profile profile2 = new Profile("profile2");
+        SwitchCommand switchCommand1 = new SwitchCommand(profile1);
+        SwitchCommand switchCommand2 = new SwitchCommand(profile1);
+        SwitchCommand switchCommand3 = new SwitchCommand(profile2);
+
+        assertEquals(switchCommand1, switchCommand2);
+        assertEquals(switchCommand1, switchCommand1);
+        assertNotEquals(switchCommand1, switchCommand3);
+        assertNotEquals("not a SwitchCommand", switchCommand1);
+        assertNotEquals(null, switchCommand1);
+    }
 
 }

--- a/src/test/java/seedu/address/logic/commands/SwitchCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/SwitchCommandTest.java
@@ -1,0 +1,114 @@
+package seedu.address.logic.commands;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static seedu.address.testutil.Assert.assertThrows;
+
+import org.junit.jupiter.api.Test;
+
+import seedu.address.logic.commands.exceptions.CommandException;
+import seedu.address.model.Model;
+import seedu.address.model.ModelManager;
+import seedu.address.model.profile.Profile;
+public class SwitchCommandTest {
+    @Test
+    public void execute_switchToValidDifferentProfile_success() throws CommandException {
+        Profile validProfile = new Profile("new-profile");
+        Model model = new ModelManager();
+        model.addToProfiles(new Profile("current-profile"));
+        model.setAddressBookFilePath(Profile.profileStringToPath("current-profile"));
+
+        SwitchCommand switchCommand = new SwitchCommand(validProfile);
+        CommandResult result = switchCommand.execute(model);
+
+        assertEquals(String.format(SwitchCommand.MESSAGE_SUCCESS, "new-profile"), result.getFeedbackToUser());
+    }
+
+    @Test
+    public void execute_boundaryProfileNames_success() throws CommandException {
+        Profile minLengthProfile = new Profile("a");
+        Model model = new ModelManager();
+        model.addToProfiles(new Profile("current-profile"));
+        model.addToProfiles(minLengthProfile);
+        model.setAddressBookFilePath(Profile.profileStringToPath("current-profile"));
+
+        SwitchCommand minSwitchCommand = new SwitchCommand(minLengthProfile);
+        CommandResult minResult = minSwitchCommand.execute(model);
+        assertEquals(String.format(SwitchCommand.MESSAGE_SUCCESS, "a"), minResult.getFeedbackToUser());
+
+        Profile maxLengthProfile = new Profile("a".repeat(30));
+        model.addToProfiles(maxLengthProfile);
+
+        SwitchCommand maxSwitchCommand = new SwitchCommand(maxLengthProfile);
+        CommandResult maxResult = maxSwitchCommand.execute(model);
+        assertEquals(String.format(SwitchCommand.MESSAGE_SUCCESS, "a".repeat(30)),
+                maxResult.getFeedbackToUser());
+    }
+
+    @Test
+    public void execute_emptyProfileListAvailableProfiles() {
+        Model model = new ModelManager();
+        model.addToProfiles(new Profile("profile1"));
+        model.addToProfiles(new Profile("profile2"));
+
+        SwitchCommand switchCommand = new SwitchCommand(Profile.getEmptyProfile());
+
+        assertThrows(CommandException.class,
+                String.format(SwitchCommand.MESSAGE_SHOW_PROFILES, "profile1, profile2", "profile1"), () ->
+                        switchCommand.execute(model)
+        );
+    }
+
+    @Test
+    public void execute_noProfilesAvailable_errorMessage() {
+        Model model = new ModelManager();
+        SwitchCommand switchCommand = new SwitchCommand(Profile.getEmptyProfile());
+
+        assertThrows(CommandException.class,
+                SwitchCommand.MESSAGE_USAGE, () -> switchCommand.execute(model)
+        );
+    }
+
+    @Test
+    public void execute_switchToCurrentProfile_error() {
+        Profile currentProfile = new Profile("active-profile");
+        Model model = new ModelManager();
+        model.addToProfiles(currentProfile);
+        model.setAddressBookFilePath(currentProfile.toPath());
+
+        SwitchCommand switchCommand = new SwitchCommand(currentProfile);
+
+        assertThrows(CommandException.class,
+                String.format(SwitchCommand.MESSAGE_NO_SWITCH, "active-profile"), () -> switchCommand.execute(model)
+        );
+    }
+
+    @Test
+    public void execute_invalidProfileName_exceptionThrown() {
+        Profile validProfile = new Profile("valid-profile");
+        String illegalModifiedProfileName = " space-in-name";
+        Model model = new ModelManager();
+        model.setAddressBookFilePath(Profile.profileStringToPath(illegalModifiedProfileName));
+
+        SwitchCommand switchCommand = new SwitchCommand(validProfile);
+
+        assertThrows(CommandException.class,
+                SwitchCommand.MESSAGE_ILLEGAL_MODIFICATION, () -> switchCommand.execute(model)
+        );
+    }
+
+    @Test
+    public void execute_invalidProfileNameWithSubDir_exceptionThrown() {
+        Profile validProfile = new Profile("valid-profile");
+        String illegalModifiedProfileName = "data/name";
+        Model model = new ModelManager();
+        model.setAddressBookFilePath(Profile.profileStringToPath(illegalModifiedProfileName));
+
+        SwitchCommand switchCommand = new SwitchCommand(validProfile);
+
+        assertThrows(CommandException.class,
+                SwitchCommand.MESSAGE_ILLEGAL_MODIFICATION, () -> switchCommand.execute(model)
+        );
+    }
+
+
+}

--- a/src/test/java/seedu/address/logic/parser/DeleteProfileCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/DeleteProfileCommandParserTest.java
@@ -1,6 +1,7 @@
 package seedu.address.logic.parser;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static seedu.address.logic.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
 import static seedu.address.testutil.Assert.assertThrows;
 
 import org.junit.jupiter.api.Test;
@@ -42,5 +43,13 @@ public class DeleteProfileCommandParserTest {
     public void parse_specialCharacterInProfileName_throwsParseException() {
         String specialCharProfileName = "john*doe";
         assertThrows(ParseException.class, () -> parser.parse(specialCharProfileName));
+    }
+
+    @Test
+    public void parse_emptyProfileName_throwParseException() {
+        String emptyStr = "";
+        assertThrows(ParseException.class,
+                String.format(MESSAGE_INVALID_COMMAND_FORMAT, DeleteProfileCommand.MESSAGE_USAGE), () ->
+                        parser.parse(emptyStr));
     }
 }

--- a/src/test/java/seedu/address/logic/parser/DeleteProfileCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/DeleteProfileCommandParserTest.java
@@ -1,0 +1,46 @@
+package seedu.address.logic.parser;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static seedu.address.testutil.Assert.assertThrows;
+
+import org.junit.jupiter.api.Test;
+
+import seedu.address.logic.commands.DeleteProfileCommand;
+import seedu.address.logic.parser.exceptions.ParseException;
+import seedu.address.model.profile.Profile;
+
+public class DeleteProfileCommandParserTest {
+    private final DeleteProfileCommandParser parser = new DeleteProfileCommandParser();
+
+    @Test
+    public void parse_validProfileName_returnsDeleteProfileCommand() throws ParseException {
+        String validProfileName = "john-doe";
+        DeleteProfileCommand resultCommand = parser.parse(validProfileName);
+        assertEquals(new DeleteProfileCommand(new Profile("john-doe")), resultCommand);
+    }
+
+    @Test
+    public void parse_invalidProfileName_throwsParseException() {
+        String invalidProfileName = "invalid name with spaces";
+        assertThrows(ParseException.class, () -> parser.parse(invalidProfileName));
+    }
+
+    @Test
+    public void parse_profileNameWithSubdirectories_throwsParseException() {
+        String invalidProfilePath = "data/invalidProfile";
+        assertThrows(ParseException.class, () -> parser.parse(invalidProfilePath));
+    }
+
+    @Test
+    public void parse_uppercaseProfileName_returnsLowercaseProfileCommand() throws ParseException {
+        String uppercaseProfileName = "JOHN-DOE";
+        DeleteProfileCommand resultCommand = parser.parse(uppercaseProfileName);
+        assertEquals(new DeleteProfileCommand(new Profile("john-doe")), resultCommand);
+    }
+
+    @Test
+    public void parse_specialCharacterInProfileName_throwsParseException() {
+        String specialCharProfileName = "john*doe";
+        assertThrows(ParseException.class, () -> parser.parse(specialCharProfileName));
+    }
+}

--- a/src/test/java/seedu/address/logic/parser/SwitchCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/SwitchCommandParserTest.java
@@ -1,0 +1,53 @@
+package seedu.address.logic.parser;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static seedu.address.testutil.Assert.assertThrows;
+
+import org.junit.jupiter.api.Test;
+
+import seedu.address.logic.commands.SwitchCommand;
+import seedu.address.logic.parser.exceptions.ParseException;
+import seedu.address.model.profile.Profile;
+
+public class SwitchCommandParserTest {
+    private final SwitchCommandParser parser = new SwitchCommandParser();
+
+    @Test
+    public void parse_emptyInput_returnsEmptyProfileCommand() throws ParseException {
+        String args = "";
+        SwitchCommand resultCommand = parser.parse(args);
+        assertEquals(new SwitchCommand(Profile.getEmptyProfile()), resultCommand);
+    }
+
+    @Test
+    public void parse_validProfileName_returnsSwitchCommand() throws ParseException {
+        String validProfileName = "john-doe";
+        SwitchCommand resultCommand = parser.parse(validProfileName);
+        assertEquals(new SwitchCommand(new Profile("john-doe")), resultCommand);
+    }
+
+    @Test
+    public void parse_invalidProfileName_throwsParseException() {
+        String invalidProfileName = "invalid name with spaces";
+        assertThrows(ParseException.class, () -> parser.parse(invalidProfileName));
+    }
+
+    @Test
+    public void parse_profileNameWithSubdirectories_throwsParseException() {
+        String invalidProfilePath = "data/invalidProfile";
+        assertThrows(ParseException.class, () -> parser.parse(invalidProfilePath));
+    }
+
+    @Test
+    public void parse_uppercaseProfileName_returnsLowercaseProfileCommand() throws ParseException {
+        String uppercaseProfileName = "JOHN-DOE";
+        SwitchCommand resultCommand = parser.parse(uppercaseProfileName);
+        assertEquals(new SwitchCommand(new Profile("john-doe")), resultCommand);
+    }
+
+    @Test
+    public void parse_specialCharacterInProfileName_throwsParseException() {
+        String specialCharProfileName = "john*doe";
+        assertThrows(ParseException.class, () -> parser.parse(specialCharProfileName));
+    }
+}

--- a/src/test/java/seedu/address/model/profile/ProfileTest.java
+++ b/src/test/java/seedu/address/model/profile/ProfileTest.java
@@ -1,0 +1,166 @@
+package seedu.address.model.profile;
+
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static seedu.address.testutil.Assert.assertThrows;
+
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.stream.Stream;
+
+import org.junit.jupiter.api.Test;
+
+import seedu.address.model.profile.exceptions.IllegalProfileNameException;
+import seedu.address.model.profile.exceptions.IllegalProfilePathException;
+
+class ProfileTest {
+
+
+    @Test
+    public void constructor_null_throwsNullPointerException() {
+        assertThrows(NullPointerException.class, () -> new Profile(null));
+    }
+
+    @Test
+    void constructor_defaultProfileName_success() {
+        Profile profile = new Profile();
+        assertEquals("addressbook", profile.toString(),
+                "Default profile name should be 'addressbook'");
+    }
+
+    @Test
+    void constructor_validProfileName_success() {
+        Profile profile = new Profile("validProfile1");
+        assertEquals("validProfile1", profile.toString(),
+                "Profile name should match the provided valid name.");
+    }
+
+    @Test
+    void constructor_invalidProfileName_throwsIllegalArgumentException() {
+        assertThrows(IllegalArgumentException.class, () -> new Profile("invalid name")); // white space
+    }
+
+    @Test
+    void isValidProfileName() {
+        //  Null case
+        assertThrows(NullPointerException.class, () -> Profile.isValidProfileName(null));
+
+        // Positive test cases (valid names)
+        assertTrue(Profile.isValidProfileName("valid_Name-123"),
+                "Should return true for names with '-' and '_'");
+        assertTrue(Profile.isValidProfileName("a"), "Should return true for single-character name");
+        assertTrue(Profile.isValidProfileName("validProfileName12345678901234"),
+                "Boundary case: Should return true for exactly 30 characters");
+
+        // Negative test cases (invalid names)
+        assertFalse(Profile.isValidProfileName("invalid name"), "Should return false for name with spaces");
+        assertFalse(Profile.isValidProfileName("invalid@name"),
+                "Should return false for name with special characters");
+        assertFalse(Profile.isValidProfileName("profileNameWithThirtyOneChars31"),
+                "Boundary case: Should return false for name with 31 characters");
+        assertFalse(Profile.isValidProfileName("aVeryLongProfileNameThatExceedsThirtyCharacters"),
+                "Should return false for name exceeding 30 characters");
+    }
+
+    @Test
+    void isValidProfileFromPath() {
+        Path validPath = Paths.get("data", "validProfile.json");
+        Path invalidPathWithInvalidName = Paths.get("data", "invalid name.json");
+        Path invalidPathWithSubfolder = Paths.get("data", "data", "invalidProfile.json");
+        Path invalidFileType = Paths.get("data", "name.txt");
+
+        assertTrue(Profile.isValidProfileFromPath(validPath),
+                "Should return true for valid profile path format and name");
+        assertFalse(Profile.isValidProfileFromPath(invalidPathWithInvalidName),
+                "Should return false for path with space");
+        assertFalse(Profile.isValidProfileFromPath(invalidPathWithSubfolder),
+                "Should return false for nested path structure");
+        assertFalse(Profile.isValidProfileFromPath(invalidFileType),
+                "Should return false for non .json files");
+    }
+
+    @Test
+    void extractProfileNameFromPathOrThrow_validPath_returnsProfileName() {
+        Path validPath = Paths.get("data", "validProfile.json");
+        assertEquals("validProfile", Profile.extractProfileNameFromPathOrThrow(validPath),
+                "Should return 'validProfile' as profile name from valid path");
+    }
+
+    @Test
+    void extractProfileNameFromPathOrThrow_invalidPath_throwsException() {
+        Path invalidPathWithSpecialChars = Paths.get("data", "invalid@profile.json");
+        Path invalidPathWithSubfolder = Paths.get("data", "subfolder", "profile.json");
+
+        assertThrows(IllegalProfileNameException.class,
+                IllegalProfileNameException.ERR_MSG, () ->
+                        Profile.extractProfileNameFromPathOrThrow(invalidPathWithSpecialChars)
+        );
+        assertThrows(IllegalProfilePathException.class,
+                IllegalProfilePathException.ERR_MSG, () ->
+                        Profile.extractProfileNameFromPathOrThrow(invalidPathWithSubfolder)
+        );
+    }
+
+    @Test
+    void extractNameFromPathOrIgnore_validPath_returnsProfileNameStream() {
+        Path validPath = Paths.get("data", "validProfile.json");
+        String extractedName = Profile.extractNameFromPathOrIgnore(validPath)
+                .findFirst()
+                .orElse(null);
+
+        assertNotNull(extractedName, "Stream should contain a profile name for valid path");
+        assertEquals("validProfile", extractedName, "Profile name should match the extracted name");
+    }
+
+    @Test
+    void extractNameFromPathOrIgnore_invalidPath_returnsEmptyStream() {
+        // Invalid path with subfolder (invalid structure)
+        Path invalidPathWithSubfolder = Paths.get("data", "subfolder", "profile.json");
+
+        // Path with invalid name (contains space)
+        Path invalidPathWithInvalidName = Paths.get("data", "invalid name.json");
+
+        Stream<String> resultStream1 = Profile.extractNameFromPathOrIgnore(invalidPathWithSubfolder);
+        Stream<String> resultStream2 = Profile.extractNameFromPathOrIgnore(invalidPathWithInvalidName);
+
+        assertTrue(resultStream1.findFirst().isEmpty(),
+                "Stream should be empty for an invalid path structure");
+        assertTrue(resultStream2.findFirst().isEmpty(),
+                "Stream should be empty for an invalid profile name in path");
+    }
+
+    @Test
+    void extractNameFromPathOrIgnore_emptyPath_returnsEmptyStream() {
+        // Path to an empty string (invalid)
+        Path emptyPath = Paths.get("");
+        Stream<String> resultStream = Profile.extractNameFromPathOrIgnore(emptyPath);
+        assertTrue(resultStream.findFirst().isEmpty(), "Stream should be empty for an empty path");
+    }
+
+    @Test
+    void toPath_correctFormatting() {
+        Profile profile = new Profile("customProfile");
+        Path expectedPath = Paths.get("data", "customProfile.json");
+        assertEquals(expectedPath, profile.toPath(), "The profile path should match the expected format");
+    }
+
+    @Test
+    void profileStringToPath() {
+        Path pathForString = Profile.profileStringToPath("a_valid_path");
+        assertEquals(Paths.get("data", "a_valid_path.json"), pathForString,
+                "Path should be 'data/a_valid_path.json'");
+
+    }
+
+    // Test EmptyProfile singleton instance
+    @Test
+    void getEmptyProfile_returnsSameInstance() {
+        Profile.EmptyProfile instanceOne = Profile.getEmptyProfile();
+        Profile.EmptyProfile instanceTwo = Profile.getEmptyProfile();
+        assertSame(instanceOne, instanceTwo, "EmptyProfile should return the same instance each time");
+    }
+}

--- a/src/test/java/seedu/address/storage/JsonAddressBookStorageTest.java
+++ b/src/test/java/seedu/address/storage/JsonAddressBookStorageTest.java
@@ -9,6 +9,7 @@ import static seedu.address.testutil.TypicalPersons.IDA;
 import static seedu.address.testutil.TypicalPersons.getTypicalAddressBook;
 
 import java.io.IOException;
+import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 
@@ -62,7 +63,10 @@ public class JsonAddressBookStorageTest {
 
     @Test
     public void readAndSaveAddressBook_allInOrder_success() throws Exception {
-        Path filePath = testFolder.resolve("TempAddressBook.json");
+
+        Path dataDirectory = testFolder.resolve("data");
+        Files.createDirectories(dataDirectory);
+        Path filePath = dataDirectory.resolve("TempAddressBook.json");
         AddressBook original = getTypicalAddressBook();
         JsonAddressBookStorage jsonAddressBookStorage = new JsonAddressBookStorage(filePath);
 

--- a/src/test/java/seedu/address/storage/StorageManagerTest.java
+++ b/src/test/java/seedu/address/storage/StorageManagerTest.java
@@ -4,6 +4,8 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static seedu.address.testutil.TypicalPersons.getTypicalAddressBook;
 
+import java.io.IOException;
+import java.nio.file.Files;
 import java.nio.file.Path;
 
 import org.junit.jupiter.api.BeforeEach;
@@ -23,8 +25,10 @@ public class StorageManagerTest {
     private StorageManager storageManager;
 
     @BeforeEach
-    public void setUp() {
-        JsonAddressBookStorage addressBookStorage = new JsonAddressBookStorage(getTempFilePath("ab"));
+    public void setUp() throws IOException {
+        Path dataDirectory = testFolder.resolve("data");
+        Files.createDirectories(dataDirectory);
+        JsonAddressBookStorage addressBookStorage = new JsonAddressBookStorage(dataDirectory.resolve("ab.json"));
         JsonUserPrefsStorage userPrefsStorage = new JsonUserPrefsStorage(getTempFilePath("prefs"));
         storageManager = new StorageManager(addressBookStorage, userPrefsStorage);
     }


### PR DESCRIPTION
Fix bugs in profile switching feature and added a delete profile command.

- update message when only `switch` or `sw` is input, to better guide users.
- profiles can be assumed to be created once a switch command is issued, although the file might only be created when the user exists the application. A normal user should not notice any inconsistency from this.
  - developers testing this should exit the program with `exit` or the 'X' button from the window, and not stop the execution from gradle
- delete profile feature is added to allow the profile feature to be more usable
- advanced users could import files into the data/ directory and use the `switch` command to access it.
  - this only work if their data files have the same format as our system

fixes #116 #143 #144 #145 