### PR TITLE
Update success message of mark and Add test for mark and list attendance commands

### DIFF
--- a/src/main/java/seedu/address/logic/commands/AttendanceMarkingCommand.java
+++ b/src/main/java/seedu/address/logic/commands/AttendanceMarkingCommand.java
@@ -1,7 +1,16 @@
 package seedu.address.logic.commands;
 
+import java.util.List;
+
+import seedu.address.model.person.Person;
+
 /**
  * Represents type of command about attendance marking, namely MarkAttendanceCommand and UnmarkAttendanceCommand.
  */
 public abstract class AttendanceMarkingCommand extends Command {
+    public static final String DISPLAY_MEMBER = "%1$s(tele: %2$s)";
+    public static List<String> displayMembers(List<Person> members) {
+        return members.stream()
+                .map(p -> String.format(DISPLAY_MEMBER, p.getName(), p.getTelegram())).toList();
+    }
 }

--- a/src/main/java/seedu/address/logic/commands/AttendanceMarkingCommand.java
+++ b/src/main/java/seedu/address/logic/commands/AttendanceMarkingCommand.java
@@ -9,6 +9,10 @@ import seedu.address.model.person.Person;
  */
 public abstract class AttendanceMarkingCommand extends Command {
     public static final String DISPLAY_MEMBER = "%1$s(tele: %2$s)";
+
+    /**
+     * Transform display of members' information to {member_name}(tele:{member_tele_handle}) format.
+     */
     public static List<String> displayMembers(List<Person> members) {
         return members.stream()
                 .map(p -> String.format(DISPLAY_MEMBER, p.getName(), p.getTelegram())).toList();

--- a/src/main/java/seedu/address/logic/commands/MarkAttendanceCommand.java
+++ b/src/main/java/seedu/address/logic/commands/MarkAttendanceCommand.java
@@ -40,7 +40,7 @@ public class MarkAttendanceCommand extends AttendanceMarkingCommand {
             + PREFIX_TELEGRAM + "berniceYu " + PREFIX_DATE + "2024-10-21";
 
     public static final String MESSAGE_MARK_MEMBER_SUCCESS =
-            "Successfully mark the attendance on %1$s for member(s): \n%2$s\n";
+            "Successfully marked the attendance on %1$s for member(s): \n%2$s\n";
     public static final String MESSAGE_CONTAIN_MARKED_MEMBER =
             "Please note that attendance of %1$s is already marked.";
 

--- a/src/main/java/seedu/address/logic/commands/MarkAttendanceCommand.java
+++ b/src/main/java/seedu/address/logic/commands/MarkAttendanceCommand.java
@@ -40,7 +40,7 @@ public class MarkAttendanceCommand extends AttendanceMarkingCommand {
             + PREFIX_TELEGRAM + "berniceYu " + PREFIX_DATE + "2024-10-21";
 
     public static final String MESSAGE_MARK_MEMBER_SUCCESS =
-            "Successfully mark the attendance on %1$s for member(s): %2$s";
+            "Successfully mark the attendance on %1$s for member(s): \n%2$s\n";
     public static final String MESSAGE_CONTAIN_MARKED_MEMBER =
             "Please note that attendance of %1$s is already marked.";
 
@@ -78,12 +78,13 @@ public class MarkAttendanceCommand extends AttendanceMarkingCommand {
         markAttendance(model, membersToMarkAttendance, this.attendance);
         model.updateFilteredPersonList(PREDICATE_SHOW_ALL_PERSONS);
 
-        List<String> peopleNames = membersAttendanceMarkSuccess.stream().map(p -> p.getName().toString()).toList();
         String commandResultMessage = this.membersAttendanceAlreadyMarked.isEmpty()
-                ? String.format(MESSAGE_MARK_MEMBER_SUCCESS, attendance, peopleNames)
-                : String.format(MESSAGE_MARK_MEMBER_SUCCESS, attendance, peopleNames)
-                + '\n' + String.format(MESSAGE_CONTAIN_MARKED_MEMBER, this.membersAttendanceAlreadyMarked.stream()
-                .map(Person::getName).toList());
+                ? String.format(MESSAGE_MARK_MEMBER_SUCCESS, attendance, displayMembers(membersAttendanceMarkSuccess))
+                : (this.membersAttendanceMarkSuccess.isEmpty()
+                    ? String.format(MESSAGE_CONTAIN_MARKED_MEMBER, displayMembers(membersAttendanceAlreadyMarked))
+                    : String.format(MESSAGE_MARK_MEMBER_SUCCESS, attendance,
+                displayMembers(membersAttendanceMarkSuccess))
+                + '\n' + String.format(MESSAGE_CONTAIN_MARKED_MEMBER, displayMembers(membersAttendanceAlreadyMarked)));
         return new CommandResult(commandResultMessage);
     }
 

--- a/src/main/java/seedu/address/logic/commands/UnmarkAttendanceCommand.java
+++ b/src/main/java/seedu/address/logic/commands/UnmarkAttendanceCommand.java
@@ -40,7 +40,7 @@ public class UnmarkAttendanceCommand extends AttendanceMarkingCommand {
             + PREFIX_TELEGRAM + "berniceYu " + PREFIX_DATE + "2024-10-21";
 
     public static final String MESSAGE_UNMARK_MEMBER_SUCCESS =
-            "Successfully unmark the attendance on %1$s for member(s):\n%2$s\n";
+            "Successfully unmarked the attendance on %1$s for member(s):\n%2$s\n";
     public static final String MESSAGE_CONTAIN_UNMARKED_MEMBER =
             "Please note that attendance of %1$s is already unmarked.";
 

--- a/src/main/java/seedu/address/logic/commands/UnmarkAttendanceCommand.java
+++ b/src/main/java/seedu/address/logic/commands/UnmarkAttendanceCommand.java
@@ -40,7 +40,7 @@ public class UnmarkAttendanceCommand extends AttendanceMarkingCommand {
             + PREFIX_TELEGRAM + "berniceYu " + PREFIX_DATE + "2024-10-21";
 
     public static final String MESSAGE_UNMARK_MEMBER_SUCCESS =
-            "Successfully unmark the attendance on %1$s for member(s): %2$s";
+            "Successfully unmark the attendance on %1$s for member(s):\n%2$s\n";
     public static final String MESSAGE_CONTAIN_UNMARKED_MEMBER =
             "Please note that attendance of %1$s is already unmarked.";
 
@@ -79,12 +79,15 @@ public class UnmarkAttendanceCommand extends AttendanceMarkingCommand {
         unmarkAttendance(model, membersToUnmarkAttendance, this.attendance);
         model.updateFilteredPersonList(PREDICATE_SHOW_ALL_PERSONS);
 
-        List<String> peopleNames = membersAttendanceUnmarkSuccess.stream().map(p -> p.getName().toString()).toList();
-        String commandResultMessage = this.membersAttendanceAlreadyUnmarked.isEmpty()
-                ? String.format(MESSAGE_UNMARK_MEMBER_SUCCESS, attendance, peopleNames)
-                : String.format(MESSAGE_UNMARK_MEMBER_SUCCESS, attendance, peopleNames)
-                + '\n' + String.format(MESSAGE_CONTAIN_UNMARKED_MEMBER, this.membersAttendanceAlreadyUnmarked.stream()
-                .map(Person::getName).toList());
+        String commandResultMessage = membersAttendanceAlreadyUnmarked.isEmpty()
+                ? String.format(MESSAGE_UNMARK_MEMBER_SUCCESS, attendance,
+                displayMembers(membersAttendanceUnmarkSuccess))
+                : (this.membersAttendanceUnmarkSuccess.isEmpty()
+                ? String.format(MESSAGE_CONTAIN_UNMARKED_MEMBER, displayMembers(membersAttendanceAlreadyUnmarked))
+                : String.format(MESSAGE_UNMARK_MEMBER_SUCCESS, attendance,
+                displayMembers(membersAttendanceUnmarkSuccess))
+                + '\n' + String.format(MESSAGE_CONTAIN_UNMARKED_MEMBER,
+                displayMembers(membersAttendanceAlreadyUnmarked)));
         return new CommandResult(commandResultMessage);
     }
 

--- a/src/test/java/seedu/address/logic/commands/ListAttendanceCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/ListAttendanceCommandTest.java
@@ -1,0 +1,84 @@
+package seedu.address.logic.commands;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static seedu.address.logic.Messages.MESSAGE_MEMBERS_LISTED_OVERVIEW;
+import static seedu.address.logic.commands.CommandTestUtil.assertCommandSuccess;
+import static seedu.address.logic.commands.CommandTestUtil.showPersonAtIndex;
+import static seedu.address.testutil.TypicalIndexes.INDEX_FIRST_PERSON;
+import static seedu.address.testutil.TypicalPersons.ALICE;
+import static seedu.address.testutil.TypicalPersons.getTypicalAddressBook;
+
+import java.util.HashSet;
+import java.util.Set;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import seedu.address.logic.Messages;
+import seedu.address.model.AddressBook;
+import seedu.address.model.Model;
+import seedu.address.model.ModelManager;
+import seedu.address.model.UserPrefs;
+import seedu.address.model.person.Person;
+import seedu.address.model.role.Member;
+
+/**
+ * Contains integration tests (interaction with the Model) and unit tests for ListAttendanceCommand.
+ */
+public class ListAttendanceCommandTest {
+
+    private Model model;
+    private Model expectedModel;
+
+    @BeforeEach
+    public void setUp() {
+        model = new ModelManager(getTypicalAddressBook(), new UserPrefs());
+        expectedModel = new ModelManager(new AddressBook(), new UserPrefs());
+    }
+
+    @Test
+    public void execute_listAttendanceIsNotFiltered_showsAllMembers() {
+        Person person1 = getTypicalAddressBook().getPersonList().get(0);
+        Person person2 = getTypicalAddressBook().getPersonList().get(2);
+
+        Person member1 = new Person(person1.getName(), person1.getPhone(),person1.getEmail(),
+                person1.getTelegram(), Set.of(new Member()), new HashSet<>(), person1.getFavouriteStatus());
+        Person member2 = new Person(person2.getName(), person2.getPhone(),person2.getEmail(),
+                person2.getTelegram(), Set.of(new Member()), new HashSet<>(), person2.getFavouriteStatus());
+        model.setPerson(model.getAddressBook().getPersonList().get(0), member1);
+        model.setPerson(model.getAddressBook().getPersonList().get(2), member2);
+
+        expectedModel.addPerson(member1);
+        expectedModel.addPerson(member2);
+
+        CommandResult commandResult = new ListAttendanceCommand().execute(model);
+        String expectedMessage = String.format(MESSAGE_MEMBERS_LISTED_OVERVIEW, 2);
+
+        assertEquals(expectedMessage, commandResult.getFeedbackToUser());
+        assertEquals(expectedModel.getFilteredPersonList(), model.getFilteredPersonList());
+    }
+
+    @Test
+    public void execute_listAttendanceIsFiltered_showsAllMembers() {
+        Person person1 = getTypicalAddressBook().getPersonList().get(0);
+        Person person2 = getTypicalAddressBook().getPersonList().get(2);
+
+        Person member1 = new Person(person1.getName(), person1.getPhone(),person1.getEmail(),
+                person1.getTelegram(), Set.of(new Member()), new HashSet<>(), person1.getFavouriteStatus());
+        Person member2 = new Person(person2.getName(), person2.getPhone(),person2.getEmail(),
+                person2.getTelegram(), Set.of(new Member()), new HashSet<>(), person2.getFavouriteStatus());
+        model.setPerson(model.getAddressBook().getPersonList().get(0), member1);
+        model.setPerson(model.getAddressBook().getPersonList().get(2), member2);
+
+        expectedModel.addPerson(member1);
+        expectedModel.addPerson(member2);
+
+        showPersonAtIndex(model, INDEX_FIRST_PERSON);
+        CommandResult commandResult = new ListAttendanceCommand().execute(model);
+        String expectedMessage = String.format(MESSAGE_MEMBERS_LISTED_OVERVIEW, 2);
+
+
+        assertEquals(expectedMessage, commandResult.getFeedbackToUser());
+        assertEquals(expectedModel.getFilteredPersonList(), model.getFilteredPersonList());
+    }
+}

--- a/src/test/java/seedu/address/logic/commands/ListAttendanceCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/ListAttendanceCommandTest.java
@@ -2,10 +2,8 @@ package seedu.address.logic.commands;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static seedu.address.logic.Messages.MESSAGE_MEMBERS_LISTED_OVERVIEW;
-import static seedu.address.logic.commands.CommandTestUtil.assertCommandSuccess;
 import static seedu.address.logic.commands.CommandTestUtil.showPersonAtIndex;
 import static seedu.address.testutil.TypicalIndexes.INDEX_FIRST_PERSON;
-import static seedu.address.testutil.TypicalPersons.ALICE;
 import static seedu.address.testutil.TypicalPersons.getTypicalAddressBook;
 
 import java.util.HashSet;
@@ -14,7 +12,6 @@ import java.util.Set;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
-import seedu.address.logic.Messages;
 import seedu.address.model.AddressBook;
 import seedu.address.model.Model;
 import seedu.address.model.ModelManager;
@@ -41,9 +38,9 @@ public class ListAttendanceCommandTest {
         Person person1 = getTypicalAddressBook().getPersonList().get(0);
         Person person2 = getTypicalAddressBook().getPersonList().get(2);
 
-        Person member1 = new Person(person1.getName(), person1.getPhone(),person1.getEmail(),
+        Person member1 = new Person(person1.getName(), person1.getPhone(), person1.getEmail(),
                 person1.getTelegram(), Set.of(new Member()), new HashSet<>(), person1.getFavouriteStatus());
-        Person member2 = new Person(person2.getName(), person2.getPhone(),person2.getEmail(),
+        Person member2 = new Person(person2.getName(), person2.getPhone(), person2.getEmail(),
                 person2.getTelegram(), Set.of(new Member()), new HashSet<>(), person2.getFavouriteStatus());
         model.setPerson(model.getAddressBook().getPersonList().get(0), member1);
         model.setPerson(model.getAddressBook().getPersonList().get(2), member2);
@@ -63,9 +60,9 @@ public class ListAttendanceCommandTest {
         Person person1 = getTypicalAddressBook().getPersonList().get(0);
         Person person2 = getTypicalAddressBook().getPersonList().get(2);
 
-        Person member1 = new Person(person1.getName(), person1.getPhone(),person1.getEmail(),
+        Person member1 = new Person(person1.getName(), person1.getPhone(), person1.getEmail(),
                 person1.getTelegram(), Set.of(new Member()), new HashSet<>(), person1.getFavouriteStatus());
-        Person member2 = new Person(person2.getName(), person2.getPhone(),person2.getEmail(),
+        Person member2 = new Person(person2.getName(), person2.getPhone(), person2.getEmail(),
                 person2.getTelegram(), Set.of(new Member()), new HashSet<>(), person2.getFavouriteStatus());
         model.setPerson(model.getAddressBook().getPersonList().get(0), member1);
         model.setPerson(model.getAddressBook().getPersonList().get(2), member2);

--- a/src/test/java/seedu/address/logic/commands/MarkAttendanceCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/MarkAttendanceCommandTest.java
@@ -99,6 +99,33 @@ public class MarkAttendanceCommandTest {
     }
 
     @Test
+    public void execute_partialDuplicateAttendance() throws Exception {
+        Attendance attendance = new Attendance("2024-10-21");
+        Person markedPerson = new PersonBuilder().withTelegram(ALICE.getTelegram().value)
+                .isMember(true).withName(ALICE.getName().fullName).withAttendance(attendance).build();
+
+        Person unmarkedPerson = new PersonBuilder().withTelegram(BENSON.getTelegram().value)
+                .isMember(true).withName(BENSON.getName().fullName).build();
+
+        model.setPerson(ALICE, markedPerson);
+        model.setPerson(BENSON, unmarkedPerson);
+
+        MarkAttendanceCommand command = new MarkAttendanceCommand(
+                Arrays.asList(ALICE.getTelegram(), BENSON.getTelegram()), attendance);
+
+        CommandResult result = command.execute(model);
+        List<Person> membersAttendanceMarked = List.of(ALICE);
+        List<Person> membersMarkSuccess = List.of(BENSON);
+
+        List<String> alreadyMarkedList = displayMembers(membersAttendanceMarked);
+        String expectedMessage = String.format(
+                MESSAGE_MARK_MEMBER_SUCCESS, attendance, displayMembers(membersMarkSuccess)) + '\n'
+                + String.format(MESSAGE_CONTAIN_MARKED_MEMBER, alreadyMarkedList);
+
+        assertEquals(expectedMessage, result.getFeedbackToUser());
+    }
+
+    @Test
     public void equals() {
         Telegram telegramAlice = new Telegram("aliceTelegram");
         Telegram telegramBob = new Telegram("bobTelegram");

--- a/src/test/java/seedu/address/logic/commands/MarkAttendanceCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/MarkAttendanceCommandTest.java
@@ -1,0 +1,135 @@
+package seedu.address.logic.commands;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static seedu.address.logic.Messages.MESSAGE_INVALID_TELEGRAM;
+import static seedu.address.logic.Messages.MESSAGE_NONMEMBER_ATTENDANCE;
+import static seedu.address.logic.commands.AttendanceMarkingCommand.displayMembers;
+import static seedu.address.logic.commands.CommandTestUtil.assertCommandSuccess;
+import static seedu.address.logic.commands.MarkAttendanceCommand.MESSAGE_CONTAIN_MARKED_MEMBER;
+import static seedu.address.logic.commands.MarkAttendanceCommand.MESSAGE_MARK_MEMBER_SUCCESS;
+import static seedu.address.testutil.Assert.assertThrows;
+import static seedu.address.testutil.TypicalPersons.ALICE;
+import static seedu.address.testutil.TypicalPersons.BENSON;
+import static seedu.address.testutil.TypicalPersons.BOB;
+import static seedu.address.testutil.TypicalPersons.getTypicalAddressBook;
+
+import org.junit.jupiter.api.Test;
+
+import seedu.address.logic.commands.exceptions.CommandException;
+import seedu.address.model.Model;
+import seedu.address.model.ModelManager;
+import seedu.address.model.UserPrefs;
+import seedu.address.model.attendance.Attendance;
+import seedu.address.model.person.Person;
+import seedu.address.model.person.Telegram;
+import seedu.address.testutil.PersonBuilder;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
+public class MarkAttendanceCommandTest {
+
+    private final Model model = new ModelManager(getTypicalAddressBook(), new UserPrefs());
+
+    @Test
+    public void execute_successfulMarkAttendance() throws Exception {
+        Model expectedModel = new ModelManager(getTypicalAddressBook(), new UserPrefs());
+
+        Attendance attendance = new Attendance("2024-10-21");
+        Person validPerson1 = new PersonBuilder().withTelegram(ALICE.getTelegram().value)
+                .isMember(true).withName(ALICE.getName().fullName).build();
+        Person validPerson2 = new PersonBuilder().withTelegram(BENSON.getTelegram().value)
+                .isMember(true).withName(BENSON.getName().fullName).build();
+        model.setPerson(ALICE, validPerson1);
+        model.setPerson(BENSON, validPerson2);
+
+        MarkAttendanceCommand command = new MarkAttendanceCommand(
+                List.of(ALICE.getTelegram(), BENSON.getTelegram()), attendance);
+
+        Person markedPerson1 = new PersonBuilder().withTelegram(ALICE.getTelegram().value)
+                .isMember(true).withName(ALICE.getName().fullName).withAttendance(attendance).build();
+        Person markedPerson2 = new PersonBuilder().withTelegram(BENSON.getTelegram().value)
+                .isMember(true).withName(BENSON.getName().fullName).withAttendance(attendance).build();
+
+        List<Person> membersAttendanceMarkSuccess = List.of(markedPerson1, markedPerson2);
+        expectedModel.setPerson(ALICE, markedPerson1);
+        expectedModel.setPerson(BENSON, markedPerson2);
+
+        String expectedMessage = String.format(
+                String.format(MESSAGE_MARK_MEMBER_SUCCESS, attendance, displayMembers(membersAttendanceMarkSuccess)));
+        assertCommandSuccess(command, model, expectedMessage, expectedModel);
+    }
+
+    @Test
+    public void execute_nonExistTelegramAttendance_throwsCommandException() {
+        Attendance attendance = new Attendance("2024-10-21");
+        MarkAttendanceCommand command = new MarkAttendanceCommand(List.of(BOB.getTelegram()), attendance);
+        String expectedMessage = String.format(MESSAGE_INVALID_TELEGRAM, List.of(BOB.getTelegram()));
+        assertThrows(CommandException.class, expectedMessage, () -> command.execute(model));
+    }
+
+    @Test
+    public void execute_nonMemberAttendance_throwsCommandException() {
+        Attendance attendance = new Attendance("2024-10-21");
+        MarkAttendanceCommand command = new MarkAttendanceCommand(List.of(BENSON.getTelegram()), attendance);
+
+        assertThrows(CommandException.class, MESSAGE_NONMEMBER_ATTENDANCE, () -> command.execute(model));
+    }
+
+    @Test
+    public void execute_duplicateAttendance() throws Exception {
+        Attendance attendance = new Attendance("2024-10-21");
+        Person markedPerson = new PersonBuilder().withTelegram(ALICE.getTelegram().value)
+                .isMember(true).withName(ALICE.getName().fullName).withAttendance(attendance).build();
+
+        model.setPerson(ALICE, markedPerson);
+
+        MarkAttendanceCommand command = new MarkAttendanceCommand(Arrays.asList(ALICE.getTelegram()), attendance);
+
+        CommandResult result = command.execute(model);
+        List<Person> membersAttendanceMarked = new ArrayList<>();
+        membersAttendanceMarked.add(ALICE);
+
+        List<String> alreadyMarkedList = displayMembers(membersAttendanceMarked);
+        assertEquals(String.format(MESSAGE_CONTAIN_MARKED_MEMBER, alreadyMarkedList),
+                result.getFeedbackToUser());
+    }
+
+    @Test
+    public void equals() {
+        Telegram telegramAlice = new Telegram("aliceTelegram");
+        Telegram telegramBob = new Telegram("bobTelegram");
+        Attendance attendance = new Attendance("2024-10-21");
+
+        MarkAttendanceCommand commandAlice = new MarkAttendanceCommand(Arrays.asList(telegramAlice), attendance);
+        MarkAttendanceCommand commandBob = new MarkAttendanceCommand(Arrays.asList(telegramBob), attendance);
+
+        // same object -> returns true
+        assertTrue(commandAlice.equals(commandAlice));
+
+        // same values -> returns true
+        MarkAttendanceCommand commandAliceCopy = new MarkAttendanceCommand(Arrays.asList(telegramAlice), attendance);
+        assertTrue(commandAlice.equals(commandAliceCopy));
+
+        // different types -> returns false
+        assertFalse(commandAlice.equals(1));
+
+        // null -> returns false
+        assertFalse(commandAlice.equals(null));
+
+        // different telegrams -> returns false
+        assertFalse(commandAlice.equals(commandBob));
+    }
+
+    @Test
+    public void toStringMethod() {
+        Telegram telegramAlice = new Telegram("aliceTelegram");
+        Attendance attendance = new Attendance("2024-10-21");
+        MarkAttendanceCommand command = new MarkAttendanceCommand(Arrays.asList(telegramAlice), attendance);
+        String expected = MarkAttendanceCommand.class.getCanonicalName() + "{telegrams=[aliceTelegram], attendance=" + attendance + "}";
+        assertEquals(expected, command.toString());
+    }
+}

--- a/src/test/java/seedu/address/logic/commands/MarkAttendanceCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/MarkAttendanceCommandTest.java
@@ -15,6 +15,10 @@ import static seedu.address.testutil.TypicalPersons.BENSON;
 import static seedu.address.testutil.TypicalPersons.BOB;
 import static seedu.address.testutil.TypicalPersons.getTypicalAddressBook;
 
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
 import org.junit.jupiter.api.Test;
 
 import seedu.address.logic.commands.exceptions.CommandException;
@@ -25,10 +29,6 @@ import seedu.address.model.attendance.Attendance;
 import seedu.address.model.person.Person;
 import seedu.address.model.person.Telegram;
 import seedu.address.testutil.PersonBuilder;
-
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.List;
 
 public class MarkAttendanceCommandTest {
 
@@ -129,7 +129,8 @@ public class MarkAttendanceCommandTest {
         Telegram telegramAlice = new Telegram("aliceTelegram");
         Attendance attendance = new Attendance("2024-10-21");
         MarkAttendanceCommand command = new MarkAttendanceCommand(Arrays.asList(telegramAlice), attendance);
-        String expected = MarkAttendanceCommand.class.getCanonicalName() + "{telegrams=[aliceTelegram], attendance=" + attendance + "}";
+        String expected = MarkAttendanceCommand.class.getCanonicalName()
+                + "{telegrams=[aliceTelegram], attendance=" + attendance + "}";
         assertEquals(expected, command.toString());
     }
 }

--- a/src/test/java/seedu/address/logic/commands/UnmarkAttendanceCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/UnmarkAttendanceCommandTest.java
@@ -15,6 +15,11 @@ import static seedu.address.testutil.TypicalPersons.BENSON;
 import static seedu.address.testutil.TypicalPersons.BOB;
 import static seedu.address.testutil.TypicalPersons.getTypicalAddressBook;
 
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+
 import org.junit.jupiter.api.Test;
 
 import seedu.address.logic.commands.exceptions.CommandException;
@@ -27,11 +32,6 @@ import seedu.address.model.person.Telegram;
 import seedu.address.model.role.Member;
 import seedu.address.testutil.PersonBuilder;
 
-import java.util.Arrays;
-import java.util.HashSet;
-import java.util.List;
-import java.util.Set;
-
 public class UnmarkAttendanceCommandTest {
 
     private final Model model = new ModelManager(getTypicalAddressBook(), new UserPrefs());
@@ -41,9 +41,9 @@ public class UnmarkAttendanceCommandTest {
         Model expectedModel = new ModelManager(getTypicalAddressBook(), new UserPrefs());
 
         Attendance attendance = new Attendance("2024-10-21");
-        Person validPerson1 = new Person(ALICE.getName(), ALICE.getPhone(),ALICE.getEmail(),
+        Person validPerson1 = new Person(ALICE.getName(), ALICE.getPhone(), ALICE.getEmail(),
                 ALICE.getTelegram(), Set.of(new Member()), Set.of(attendance), ALICE.getFavouriteStatus());
-        Person validPerson2 = new Person(BENSON.getName(), BENSON.getPhone(),BENSON.getEmail(),
+        Person validPerson2 = new Person(BENSON.getName(), BENSON.getPhone(), BENSON.getEmail(),
                 BENSON.getTelegram(), Set.of(new Member()), Set.of(attendance), BENSON.getFavouriteStatus());
         model.setPerson(ALICE, validPerson1);
         model.setPerson(BENSON, validPerson2);
@@ -51,9 +51,9 @@ public class UnmarkAttendanceCommandTest {
         UnmarkAttendanceCommand command = new UnmarkAttendanceCommand(
                 List.of(ALICE.getTelegram(), BENSON.getTelegram()), attendance);
 
-        Person unmarkedPerson1 = new Person(ALICE.getName(), ALICE.getPhone(),ALICE.getEmail(),
+        Person unmarkedPerson1 = new Person(ALICE.getName(), ALICE.getPhone(), ALICE.getEmail(),
                 ALICE.getTelegram(), Set.of(new Member()), new HashSet<>(), ALICE.getFavouriteStatus());
-        Person unmarkedPerson2 = new Person(BENSON.getName(), BENSON.getPhone(),BENSON.getEmail(),
+        Person unmarkedPerson2 = new Person(BENSON.getName(), BENSON.getPhone(), BENSON.getEmail(),
                 BENSON.getTelegram(), Set.of(new Member()), new HashSet<>(), BENSON.getFavouriteStatus());
         expectedModel.setPerson(ALICE, unmarkedPerson1);
         expectedModel.setPerson(BENSON, unmarkedPerson2);
@@ -116,7 +116,8 @@ public class UnmarkAttendanceCommandTest {
         assertTrue(commandAlice.equals(commandAlice));
 
         // same values -> returns true
-        UnmarkAttendanceCommand commandAliceCopy = new UnmarkAttendanceCommand(Arrays.asList(telegramAlice), attendance);
+        UnmarkAttendanceCommand commandAliceCopy = new UnmarkAttendanceCommand(
+                Arrays.asList(telegramAlice), attendance);
         assertTrue(commandAlice.equals(commandAliceCopy));
 
         // different types -> returns false
@@ -134,7 +135,8 @@ public class UnmarkAttendanceCommandTest {
         Telegram telegramAlice = new Telegram("aliceTelegram");
         Attendance attendance = new Attendance("2024-10-21");
         UnmarkAttendanceCommand command = new UnmarkAttendanceCommand(Arrays.asList(telegramAlice), attendance);
-        String expected = UnmarkAttendanceCommand.class.getCanonicalName() + "{telegrams=[aliceTelegram], attendance=" + attendance + "}";
+        String expected = UnmarkAttendanceCommand.class.getCanonicalName()
+                + "{telegrams=[aliceTelegram], attendance=" + attendance + "}";
         assertEquals(expected, command.toString());
     }
 }

--- a/src/test/java/seedu/address/logic/commands/UnmarkAttendanceCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/UnmarkAttendanceCommandTest.java
@@ -1,0 +1,140 @@
+package seedu.address.logic.commands;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static seedu.address.logic.Messages.MESSAGE_INVALID_TELEGRAM;
+import static seedu.address.logic.Messages.MESSAGE_NONMEMBER_ATTENDANCE;
+import static seedu.address.logic.commands.AttendanceMarkingCommand.displayMembers;
+import static seedu.address.logic.commands.CommandTestUtil.assertCommandSuccess;
+import static seedu.address.logic.commands.UnmarkAttendanceCommand.MESSAGE_CONTAIN_UNMARKED_MEMBER;
+import static seedu.address.logic.commands.UnmarkAttendanceCommand.MESSAGE_UNMARK_MEMBER_SUCCESS;
+import static seedu.address.testutil.Assert.assertThrows;
+import static seedu.address.testutil.TypicalPersons.ALICE;
+import static seedu.address.testutil.TypicalPersons.BENSON;
+import static seedu.address.testutil.TypicalPersons.BOB;
+import static seedu.address.testutil.TypicalPersons.getTypicalAddressBook;
+
+import org.junit.jupiter.api.Test;
+
+import seedu.address.logic.commands.exceptions.CommandException;
+import seedu.address.model.Model;
+import seedu.address.model.ModelManager;
+import seedu.address.model.UserPrefs;
+import seedu.address.model.attendance.Attendance;
+import seedu.address.model.person.Person;
+import seedu.address.model.person.Telegram;
+import seedu.address.model.role.Member;
+import seedu.address.testutil.PersonBuilder;
+
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+
+public class UnmarkAttendanceCommandTest {
+
+    private final Model model = new ModelManager(getTypicalAddressBook(), new UserPrefs());
+
+    @Test
+    public void execute_successfulUnmarkAttendance() throws Exception {
+        Model expectedModel = new ModelManager(getTypicalAddressBook(), new UserPrefs());
+
+        Attendance attendance = new Attendance("2024-10-21");
+        Person validPerson1 = new Person(ALICE.getName(), ALICE.getPhone(),ALICE.getEmail(),
+                ALICE.getTelegram(), Set.of(new Member()), Set.of(attendance), ALICE.getFavouriteStatus());
+        Person validPerson2 = new Person(BENSON.getName(), BENSON.getPhone(),BENSON.getEmail(),
+                BENSON.getTelegram(), Set.of(new Member()), Set.of(attendance), BENSON.getFavouriteStatus());
+        model.setPerson(ALICE, validPerson1);
+        model.setPerson(BENSON, validPerson2);
+
+        UnmarkAttendanceCommand command = new UnmarkAttendanceCommand(
+                List.of(ALICE.getTelegram(), BENSON.getTelegram()), attendance);
+
+        Person unmarkedPerson1 = new Person(ALICE.getName(), ALICE.getPhone(),ALICE.getEmail(),
+                ALICE.getTelegram(), Set.of(new Member()), new HashSet<>(), ALICE.getFavouriteStatus());
+        Person unmarkedPerson2 = new Person(BENSON.getName(), BENSON.getPhone(),BENSON.getEmail(),
+                BENSON.getTelegram(), Set.of(new Member()), new HashSet<>(), BENSON.getFavouriteStatus());
+        expectedModel.setPerson(ALICE, unmarkedPerson1);
+        expectedModel.setPerson(BENSON, unmarkedPerson2);
+
+        List<Person> membersAttendanceUnmarkSuccess = List.of(ALICE, BENSON);
+
+        String expectedMessage = String.format(String.format(MESSAGE_UNMARK_MEMBER_SUCCESS,
+                attendance, displayMembers(membersAttendanceUnmarkSuccess)));
+
+        assertCommandSuccess(command, model, expectedMessage, expectedModel);
+    }
+
+    @Test
+    public void execute_nonExistTelegramAttendance_throwsCommandException() {
+        Attendance attendance = new Attendance("2024-10-21");
+        UnmarkAttendanceCommand command = new UnmarkAttendanceCommand(List.of(BOB.getTelegram()), attendance);
+        String expectedMessage = String.format(MESSAGE_INVALID_TELEGRAM, List.of(BOB.getTelegram()));
+        assertThrows(CommandException.class, expectedMessage, () -> command.execute(model));
+    }
+
+    @Test
+    public void execute_nonMemberAttendance_throwsCommandException() {
+        Attendance attendance = new Attendance("2024-10-21");
+        Person memberBenson = new PersonBuilder().withTelegram(BENSON.getTelegram().value)
+                .isMember(false).withName(BENSON.getName().fullName).withAttendance(attendance).build();
+        model.setPerson(BENSON, memberBenson);
+        MarkAttendanceCommand command = new MarkAttendanceCommand(List.of(BENSON.getTelegram()), attendance);
+
+        assertThrows(CommandException.class, MESSAGE_NONMEMBER_ATTENDANCE, () -> command.execute(model));
+    }
+
+    @Test
+    public void execute_duplicateAttendance() throws Exception {
+        Attendance attendance = new Attendance("2024-10-21");
+        Person unmarkedPerson = new PersonBuilder().withTelegram(ALICE.getTelegram().value)
+                .isMember(true).withName(ALICE.getName().fullName).build();
+
+        List<Person> membersAttendanceUnmarked = List.of(unmarkedPerson);
+        model.setPerson(ALICE, unmarkedPerson);
+
+        UnmarkAttendanceCommand command = new UnmarkAttendanceCommand(Arrays.asList(ALICE.getTelegram()), attendance);
+
+        CommandResult result = command.execute(model);
+
+        List<String> alreadyMarkedList = displayMembers(membersAttendanceUnmarked);
+        assertEquals(String.format(MESSAGE_CONTAIN_UNMARKED_MEMBER, alreadyMarkedList),
+                result.getFeedbackToUser());
+    }
+
+    @Test
+    public void equals() {
+        Telegram telegramAlice = new Telegram("aliceTelegram");
+        Telegram telegramBob = new Telegram("bobTelegram");
+        Attendance attendance = new Attendance("2024-10-21");
+
+        UnmarkAttendanceCommand commandAlice = new UnmarkAttendanceCommand(Arrays.asList(telegramAlice), attendance);
+        UnmarkAttendanceCommand commandBob = new UnmarkAttendanceCommand(Arrays.asList(telegramBob), attendance);
+
+        // same object -> returns true
+        assertTrue(commandAlice.equals(commandAlice));
+
+        // same values -> returns true
+        UnmarkAttendanceCommand commandAliceCopy = new UnmarkAttendanceCommand(Arrays.asList(telegramAlice), attendance);
+        assertTrue(commandAlice.equals(commandAliceCopy));
+
+        // different types -> returns false
+        assertFalse(commandAlice.equals(1));
+
+        // null -> returns false
+        assertFalse(commandAlice.equals(null));
+
+        // different telegrams -> returns false
+        assertFalse(commandAlice.equals(commandBob));
+    }
+
+    @Test
+    public void toStringMethod() {
+        Telegram telegramAlice = new Telegram("aliceTelegram");
+        Attendance attendance = new Attendance("2024-10-21");
+        UnmarkAttendanceCommand command = new UnmarkAttendanceCommand(Arrays.asList(telegramAlice), attendance);
+        String expected = UnmarkAttendanceCommand.class.getCanonicalName() + "{telegrams=[aliceTelegram], attendance=" + attendance + "}";
+        assertEquals(expected, command.toString());
+    }
+}

--- a/src/test/java/seedu/address/logic/commands/UnmarkAttendanceCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/UnmarkAttendanceCommandTest.java
@@ -98,9 +98,35 @@ public class UnmarkAttendanceCommandTest {
 
         CommandResult result = command.execute(model);
 
-        List<String> alreadyMarkedList = displayMembers(membersAttendanceUnmarked);
-        assertEquals(String.format(MESSAGE_CONTAIN_UNMARKED_MEMBER, alreadyMarkedList),
+        List<String> alreadyUnarkedList = displayMembers(membersAttendanceUnmarked);
+        assertEquals(String.format(MESSAGE_CONTAIN_UNMARKED_MEMBER, alreadyUnarkedList),
                 result.getFeedbackToUser());
+    }
+
+    @Test
+    public void execute_unmarkDuplicateAttendance() throws Exception {
+        Attendance attendance = new Attendance("2024-10-21");
+        Person unmarkedPerson = new PersonBuilder().withTelegram(ALICE.getTelegram().value)
+                .isMember(true).withName(ALICE.getName().fullName).build();
+        Person markedPerson = new PersonBuilder().withTelegram(BENSON.getTelegram().value)
+                .isMember(true).withName(BENSON.getName().fullName).withAttendance(attendance).build();
+
+        List<Person> membersAttendanceUnmarked = List.of(unmarkedPerson);
+        model.setPerson(ALICE, unmarkedPerson);
+        model.setPerson(BENSON, markedPerson);
+
+        UnmarkAttendanceCommand command = new UnmarkAttendanceCommand(
+                Arrays.asList(ALICE.getTelegram(), BENSON.getTelegram()), attendance);
+
+        CommandResult result = command.execute(model);
+
+        List<String> alreadyUnmarkedList = displayMembers(membersAttendanceUnmarked);
+        List<String> unmarkSuccessList = displayMembers(List.of(BENSON));
+        String expectedMessage = String.format(
+                MESSAGE_UNMARK_MEMBER_SUCCESS, attendance, unmarkSuccessList) + '\n'
+                + String.format(MESSAGE_CONTAIN_UNMARKED_MEMBER, alreadyUnmarkedList);
+
+        assertEquals(expectedMessage, result.getFeedbackToUser());
     }
 
     @Test

--- a/src/test/java/seedu/address/testutil/PersonBuilder.java
+++ b/src/test/java/seedu/address/testutil/PersonBuilder.java
@@ -101,6 +101,25 @@ public class PersonBuilder {
     }
 
     /**
+     * Add or remove role {@code Member} to the {@code Role} of the {@code Person} based on input {@code b}.
+     */
+    public PersonBuilder isMember(boolean b) {
+        this.roles.remove(new Member());
+        if (b) {
+            this.roles.add(new Member());
+        }
+        return this;
+    }
+
+    /**
+     * Add {@code attendance} to the {@code Attendance} of the {@code Person} that we are building.
+     */
+    public PersonBuilder withAttendance(Attendance attendance) {
+        this.attendance.add(attendance);
+        return this;
+    }
+
+    /**
      * Sets the {@code FavouriteStatus} of the {@code Person} that we are building.
      */
     public PersonBuilder withFavourite() {
@@ -110,18 +129,5 @@ public class PersonBuilder {
 
     public Person build() {
         return new Person(name, phone, email, telegram, roles, attendance, favouriteStatus);
-    }
-
-    public PersonBuilder isMember(boolean b) {
-        this.roles.remove(new Member());
-        if (b) {
-            this.roles.add(new Member());
-        }
-        return this;
-    }
-
-    public PersonBuilder withAttendance(Attendance attendance) {
-        this.attendance.add(attendance);
-        return this;
     }
 }

--- a/src/test/java/seedu/address/testutil/PersonBuilder.java
+++ b/src/test/java/seedu/address/testutil/PersonBuilder.java
@@ -10,6 +10,7 @@ import seedu.address.model.person.Name;
 import seedu.address.model.person.Person;
 import seedu.address.model.person.Phone;
 import seedu.address.model.person.Telegram;
+import seedu.address.model.role.Member;
 import seedu.address.model.role.Role;
 import seedu.address.model.util.SampleDataUtil;
 
@@ -111,4 +112,16 @@ public class PersonBuilder {
         return new Person(name, phone, email, telegram, roles, attendance, favouriteStatus);
     }
 
+    public PersonBuilder isMember(boolean b) {
+        this.roles.remove(new Member());
+        if (b) {
+            this.roles.add(new Member());
+        }
+        return this;
+    }
+
+    public PersonBuilder withAttendance(Attendance attendance) {
+        this.attendance.add(attendance);
+        return this;
+    }
 }


### PR DESCRIPTION
- Fixes #166 
   If there's no new changes to attendance mark/unmark status of incoming members, the message will only display the repeated members.
   New display to distinguish member with same name in `mark` and `unmark` success message: 
![image](https://github.com/user-attachments/assets/7ab9c9ef-6963-4d6a-a785-f9ea6de1239f)

- Add testcases for class `ListAttendanceCommand`, `MarkAttendanceCommand`, `UnmarkAttendanceCommand`