### PR TITLE
update `switch` to reset filtered list after each profile switch

### DIFF
--- a/src/main/java/seedu/address/logic/commands/SwitchCommand.java
+++ b/src/main/java/seedu/address/logic/commands/SwitchCommand.java
@@ -2,6 +2,7 @@ package seedu.address.logic.commands;
 
 import static java.util.Objects.requireNonNull;
 import static seedu.address.logic.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
+import static seedu.address.model.Model.PREDICATE_SHOW_ALL_PERSONS;
 import static seedu.address.model.profile.Profile.extractProfileNameFromPathOrThrow;
 
 import java.nio.file.Path;
@@ -65,6 +66,8 @@ public class SwitchCommand extends Command {
         model.removeFromProfiles(profile);
         model.setAddressBookFilePath(filePath);
 
+        model.updateFilteredPersonList(PREDICATE_SHOW_ALL_PERSONS);
+        model.setSortedListToDefault();
         return new CommandResult(String.format(MESSAGE_SUCCESS, profile)).markProfileSwitched();
     }
 


### PR DESCRIPTION
previously `sort` and `find` on a profile will affect the filtered list of other profiles, making them dependent

`switch` will now reset the filtered list to the default sort order and show all persons after every switch.

fixes #247 