### PR TITLE
Fix bug where past attendance dates overflow screen

### DIFF
--- a/src/main/java/seedu/address/ui/ViewPersonCard.java
+++ b/src/main/java/seedu/address/ui/ViewPersonCard.java
@@ -5,6 +5,7 @@ import java.util.logging.Logger;
 
 import javafx.fxml.FXML;
 import javafx.scene.control.Label;
+import javafx.scene.control.ScrollPane;
 import javafx.scene.layout.FlowPane;
 import javafx.scene.layout.Region;
 import javafx.scene.layout.VBox;
@@ -44,6 +45,9 @@ public class ViewPersonCard extends UiPart<Region> {
     @FXML
     private FlowPane viewAttendance;
 
+    @FXML
+    private ScrollPane viewScroll;
+
     /**
      * Creates a {@code ViewPersonCard} with the given {@code Person}.
      */
@@ -73,6 +77,8 @@ public class ViewPersonCard extends UiPart<Region> {
         viewRoles.getChildren().stream().map(node -> (Label) node)
                 .filter(label -> label.getText().equals(Member.MEMBER_ROLE))
                 .forEach(label -> label.setId("memberRole"));
+        viewScroll.setHbarPolicy(ScrollPane.ScrollBarPolicy.NEVER);
+        viewScroll.setVbarPolicy(ScrollPane.ScrollBarPolicy.ALWAYS);
     }
 
     public Label getViewName() {

--- a/src/main/resources/view/ViewPersonCard.fxml
+++ b/src/main/resources/view/ViewPersonCard.fxml
@@ -7,10 +7,10 @@
 
 <?import javafx.scene.layout.FlowPane?>
 <?import javafx.scene.layout.HBox?>
-
 <?import javafx.scene.layout.GridPane?>
 
-<VBox fx:id="view" xmlns="http://javafx.com/javafx/17" xmlns:fx="http://javafx.com/fxml/1">
+<?import javafx.scene.control.ScrollPane?>
+<VBox fx:id="view" xmlns="http://javafx.com/javafx/17" xmlns:fx="http://javafx.com/fxml/1" VBox.vgrow="ALWAYS">
     <Label id="viewTitle" fx:id="viewTitle" />
     <GridPane>
     <HBox alignment="BASELINE_LEFT" prefWidth="1250">
@@ -33,9 +33,11 @@
         <Label id="viewLabel" text="Roles: "/>
         <FlowPane fx:id="viewRoles" />
     </HBox>
-    <HBox alignment="BASELINE_LEFT">
+    <HBox alignment="TOP_LEFT" style="-fx-background-color: transparent">
         <Label id="viewLabel" text="Sessions Attended: "/>
-        <FlowPane fx:id="viewAttendance" />
+        <ScrollPane id="viewScroll" fx:id="viewScroll" maxHeight="200" style="-fx-background-color: transparent; -fx-background: transparent">
+            <FlowPane fx:id="viewAttendance" VBox.vgrow="ALWAYS"/>
+        </ScrollPane>
     </HBox>
     <stylesheets>
         <URL value="@ViewPersonCard.css"/>


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/c3f90a35-8b2e-468b-946a-d4d927e47dcd)
> This commit adds GUI changes!!!

I believe this is a bug that requires fixing, as screen cannot be resized to see past attendance dates that have overflowed. As such, this indeed impedes the functionality of the feature as not all past attended dates of the contact can be seen.
___

This commit makes only the attendance section in the `view` page scrollable. Fixes #220 
![image](https://github.com/user-attachments/assets/007c77de-2f1b-47b1-9c7b-9714fbc24fd7)
